### PR TITLE
Add header required by git-updater plugin

### DIFF
--- a/wp-openid-connect-server.php
+++ b/wp-openid-connect-server.php
@@ -5,6 +5,7 @@
  * Author: Automattic
  * Author URI: https://automattic.com/
  * Plugin URI: https://github.com/Automattic/wp-openid-connect-server
+ * GitHub Plugin URI: Automattic/wp-openid-connect-server
  * Version: 1.0
  */
 namespace OpenIDConnectServer;


### PR DESCRIPTION
So that the plugin can be updated by https://github.com/afragen/git-updater.

See [git-updater's docs](https://github.com/afragen/git-updater#description) for more information.