### PR TITLE
provide picture claim in userInfo endpoint response

### DIFF
--- a/class-oauth2-storage.php
+++ b/class-oauth2-storage.php
@@ -299,6 +299,7 @@ class OAuth2_Storage implements OAuth2\Storage\ClientInterface, OAuth2\Storage\C
 							$claims[ $key ] = $user->$value;
 						}
 					}
+					$claims['picture'] = \get_avatar_url( $user->user_email );
 				}
 			}
 		}


### PR DESCRIPTION
In order to automatically allow setting the avatar on the OpenID client, we need to provide the picture.