### PR TITLE
account for sub-directories WP install when checking for authenticate endpoint

### DIFF
--- a/class-openid-connect-server.php
+++ b/class-openid-connect-server.php
@@ -93,9 +93,12 @@ class OpenIDConnectServer {
 	}
 
 	public function openid_authenticate() {
-		if ( 0 !== strpos( $_SERVER['REQUEST_URI'], '/openid-connect/authenticate' ) ) {
+		global $wp;
+
+		if ( $wp->request !== 'openid-connect/authenticate' ) {
 			return;
 		}
+
 		$request = OAuth2\Request::createFromGlobals();
 		if ( empty( $request->query( 'client_id' ) ) || ! OAuth2_Storage::getClientName( $request->query( 'client_id' ) ) ) {
 			return;


### PR DESCRIPTION
This PR brings the change in checking for authenticate endpoint by using request path identified by WordPress instead of `$_SERVER['REQUEST_URI']` so that WP installs under sub-directories also work