### PR TITLE
Fix token generation in overridden authorize controller

### DIFF
--- a/src/Overrides/OpenID/Controller/AuthorizeController.php
+++ b/src/Overrides/OpenID/Controller/AuthorizeController.php
@@ -9,10 +9,14 @@ use OAuth2\OpenID\Controller\AuthorizeController as BaseOpenIDAuthorizeControlle
 use OAuth2\OpenID\ResponseType\IdToken;
 use OAuth2\Storage\ClientInterface;
 use OAuth2\ScopeInterface;
+use OpenIDConnectServer\Storage\UserClaimsStorage;
 
 class AuthorizeController extends BaseOpenIDAuthorizeController {
-	public function __construct( ClientInterface $clientStorage, array $responseTypes, array $config, ScopeInterface $scopeUtil ) {
+	private UserClaimsStorage $user_claims_storage;
+
+	public function __construct( ClientInterface $clientStorage, array $responseTypes, array $config, ScopeInterface $scopeUtil, UserClaimsStorage $userClaimsStorage ) {
 		parent::__construct( $clientStorage, $responseTypes, $config, $scopeUtil );
+		$this->user_claims_storage = $userClaimsStorage;
 	}
 
 	protected function buildAuthorizeParameters( $request, $response, $user_id ) {
@@ -28,7 +32,7 @@ class AuthorizeController extends BaseOpenIDAuthorizeController {
 		/** @var IdToken $id_token */
 		$id_token = $this->responseTypes['id_token'];
 
-		$userClaims         = $this->clientStorage->getUserClaims( $user_id, $params['scope'] );
+		$userClaims         = $this->user_claims_storage->getUserClaims( $user_id, $params['scope'] );
 		$params['id_token'] = $id_token->createIdToken( $this->getClientId(), $user_id, $this->getNonce(), $userClaims );
 
 		return $params;

--- a/src/Overrides/OpenID/Controller/AuthorizeController.php
+++ b/src/Overrides/OpenID/Controller/AuthorizeController.php
@@ -15,14 +15,15 @@ class AuthorizeController extends BaseOpenIDAuthorizeController {
 			return;
 		}
 
-		// Generate an id token if needed.
-		if ( $this->needsIdToken( $this->getScope() ) && $this->getResponseType() === self::RESPONSE_TYPE_AUTHORIZATION_CODE ) {
-			$userClaims         = $this->clientStorage->getUserClaims( $user_id, $params['scope'] );
-
-			/** @var IdToken $id_token */
-			$id_token = $this->responseTypes['id_token'];
-			$params['id_token'] = $id_token->createIdToken( $this->getClientId(), $user_id, $this->getNonce(), $userClaims );
+		if ( ! $this->needsIdToken( $this->getScope() ) || self::RESPONSE_TYPE_AUTHORIZATION_CODE !== $this->getResponseType() ) {
+			return $params;
 		}
+
+		/** @var IdToken $id_token */
+		$id_token = $this->responseTypes['id_token'];
+
+		$userClaims         = $this->clientStorage->getUserClaims( $user_id, $params['scope'] );
+		$params['id_token'] = $id_token->createIdToken( $this->getClientId(), $user_id, $this->getNonce(), $userClaims );
 
 		return $params;
 	}

--- a/src/Overrides/OpenID/Controller/AuthorizeController.php
+++ b/src/Overrides/OpenID/Controller/AuthorizeController.php
@@ -17,11 +17,8 @@ class AuthorizeController extends BaseOpenIDAuthorizeController {
 		// Generate an id token if needed.
 		if ( $this->needsIdToken( $this->getScope() ) && $this->getResponseType() === self::RESPONSE_TYPE_AUTHORIZATION_CODE ) {
 			// START MODIFICATION.
-			// we obtain response and parse out id_token from it, since we need user claims for the right token, which we don't have access to here
-			list( $redirect_uri, $response ) = $this->responseTypes['id_token']->getAuthorizeResponse(
-				array( 'client_id' => $this->getClientId(), 'nonce' => $this->getNonce(), 'scope' => $this->getScope(), 'state' => $this->getState(), 'redirect_uri' => $this->getRedirectUri() )
-			);
-			$params['id_token'] = $response['fragment']['id_token'];
+			$userClaims         = $this->clientStorage->getUserClaims( $user_id, $params['scope'] );
+			$params['id_token'] = $this->responseTypes['id_token']->createIdToken( $this->getClientId(), $user_id, $this->getNonce(), $userClaims );
 			// END MODIFICATION.
 		}
 

--- a/src/Overrides/OpenID/Controller/AuthorizeController.php
+++ b/src/Overrides/OpenID/Controller/AuthorizeController.php
@@ -24,9 +24,6 @@ class AuthorizeController extends BaseOpenIDAuthorizeController {
 			$params['id_token'] = $id_token->createIdToken( $this->getClientId(), $user_id, $this->getNonce(), $userClaims );
 		}
 
-		// Add the nonce to return with the redirect URI.
-		$params['nonce'] = $this->getNonce();
-
 		return $params;
 	}
 }

--- a/src/Overrides/OpenID/Controller/AuthorizeController.php
+++ b/src/Overrides/OpenID/Controller/AuthorizeController.php
@@ -7,8 +7,14 @@ namespace OpenIDConnectServer\Overrides\OpenID\Controller;
 
 use OAuth2\OpenID\Controller\AuthorizeController as BaseOpenIDAuthorizeController;
 use OAuth2\OpenID\ResponseType\IdToken;
+use OAuth2\Storage\ClientInterface;
+use OAuth2\ScopeInterface;
 
 class AuthorizeController extends BaseOpenIDAuthorizeController {
+	public function __construct( ClientInterface $clientStorage, array $responseTypes, array $config, ScopeInterface $scopeUtil ) {
+		parent::__construct( $clientStorage, $responseTypes, $config, $scopeUtil );
+	}
+
 	protected function buildAuthorizeParameters( $request, $response, $user_id ) {
 		$params = parent::buildAuthorizeParameters( $request, $response, $user_id );
 		if ( ! $params ) {

--- a/src/Overrides/OpenID/Controller/AuthorizeController.php
+++ b/src/Overrides/OpenID/Controller/AuthorizeController.php
@@ -6,6 +6,7 @@
 namespace OpenIDConnectServer\Overrides\OpenID\Controller;
 
 use OAuth2\OpenID\Controller\AuthorizeController as BaseOpenIDAuthorizeController;
+use OAuth2\OpenID\ResponseType\IdToken;
 
 class AuthorizeController extends BaseOpenIDAuthorizeController {
 	protected function buildAuthorizeParameters( $request, $response, $user_id ) {
@@ -16,10 +17,11 @@ class AuthorizeController extends BaseOpenIDAuthorizeController {
 
 		// Generate an id token if needed.
 		if ( $this->needsIdToken( $this->getScope() ) && $this->getResponseType() === self::RESPONSE_TYPE_AUTHORIZATION_CODE ) {
-			// START MODIFICATION.
 			$userClaims         = $this->clientStorage->getUserClaims( $user_id, $params['scope'] );
-			$params['id_token'] = $this->responseTypes['id_token']->createIdToken( $this->getClientId(), $user_id, $this->getNonce(), $userClaims );
-			// END MODIFICATION.
+
+			/** @var IdToken $id_token */
+			$id_token = $this->responseTypes['id_token'];
+			$params['id_token'] = $id_token->createIdToken( $this->getClientId(), $user_id, $this->getNonce(), $userClaims );
 		}
 
 		// Add the nonce to return with the redirect URI.

--- a/src/Overrides/OpenID/Controller/AuthorizeController.php
+++ b/src/Overrides/OpenID/Controller/AuthorizeController.php
@@ -17,8 +17,11 @@ class AuthorizeController extends BaseOpenIDAuthorizeController {
 		// Generate an id token if needed.
 		if ( $this->needsIdToken( $this->getScope() ) && $this->getResponseType() === self::RESPONSE_TYPE_AUTHORIZATION_CODE ) {
 			// START MODIFICATION.
-			$userClaims         = $this->clientStorage->getUserClaims( $user_id, $params['scope'] );
-			$params['id_token'] = $this->responseTypes['id_token']->createIdToken( $this->getClientId(), $user_id, $this->getNonce(), $userClaims );
+			// we obtain response and parse out id_token from it, since we need user claims for the right token, which we don't have access to here
+			list( $redirect_uri, $response ) = $this->responseTypes['id_token']->getAuthorizeResponse(
+				array( 'client_id' => $this->getClientId(), 'nonce' => $this->getNonce(), 'scope' => $this->getScope(), 'state' => $this->getState(), 'redirect_uri' => $this->getRedirectUri() )
+			);
+			$params['id_token'] = $response['fragment']['id_token'];
 			// END MODIFICATION.
 		}
 

--- a/src/Overrides/Server.php
+++ b/src/Overrides/Server.php
@@ -7,6 +7,7 @@ namespace OpenIDConnectServer\Overrides;
 use OAuth2\Server as BaseServer;
 use OAuth2\OpenID\Controller\AuthorizeController as BaseAuthorizeController;
 use OpenIDConnectServer\Overrides\OpenID\Controller\AuthorizeController;
+use OpenIDConnectServer\Storage\UserClaimsStorage;
 
 class Server extends BaseServer {
 	protected function createDefaultAuthorizeController() {
@@ -15,7 +16,7 @@ class Server extends BaseServer {
 		if ( $controller instanceof BaseAuthorizeController ) {
 			// Override it with our own controller.
 			$config     = array_intersect_key( $this->config, array_flip( explode( ' ', 'allow_implicit enforce_state require_exact_redirect_uri' ) ) );
-			$controller = new AuthorizeController( $this->storages['client'], $this->responseTypes, $config, $this->getScopeUtil() );
+			$controller = new AuthorizeController( $this->storages['client'], $this->responseTypes, $config, $this->getScopeUtil(), new UserClaimsStorage() );
 		}
 
 		return $controller;

--- a/src/Storage/AuthorizationCodeStorage.php
+++ b/src/Storage/AuthorizationCodeStorage.php
@@ -76,7 +76,7 @@ class AuthorizationCodeStorage implements AuthorizationCodeInterface {
 					'user_id'      => 'user_login',
 					'expires'      => 'expires',
 					'redirect_uri' => 'redirect_uri',
-					'scope'        => 'scope',
+					'id_token'     => 'id_token',
 				) as $key => $meta_key
 			) {
 				$authorization_code[ $key ] = get_term_meta( $term->term_id, $meta_key, true );

--- a/src/Storage/UserClaimsStorage.php
+++ b/src/Storage/UserClaimsStorage.php
@@ -16,7 +16,7 @@ class UserClaimsStorage implements UserClaimsInterface {
 		}
 
 		$scopes = explode( ' ', $scope );
-		if ( ! isset( $scopes['profile'] ) ) {
+		if ( ! in_array( 'profile', $scopes, true ) ) {
 			return $claims;
 		}
 


### PR DESCRIPTION
This PR fixes the following fatal error I encountered with SSO:

```
<b>Fatal error</b>:  Uncaught Error: Call to undefined method OpenIDConnectServer\Storage\ClientCredentialsStorage::getUserClaims() in /var/www/wp/wp-content/plugins/wp-openid-connect-server-rsync/src/Overrides/OpenID/Controller/AuthorizeController.php:20
Stack trace:
#0 /var/www/wp/wp-content/plugins/wp-openid-connect-server-rsync/vendor/bshaffer/oauth2-server-php/src/OAuth2/Controller/AuthorizeController.php(135): OpenIDConnectServer\Overrides\OpenID\Controller\AuthorizeController-&gt;buildAuthorizeParameters()
#1 /var/www/wp/wp-content/plugins/wp-openid-connect-server-rsync/vendor/bshaffer/oauth2-server-php/src/OAuth2/Server.php(383): OAuth2\Controller\AuthorizeController-&gt;handleAuthorizeRequest()
#2 /var/www/wp/wp-content/plugins/wp-openid-connect-server-rsync/src/Http/Handlers/AuthorizeHandler.php(45): OAuth2\Server-&gt;handleAuthorizeRequest()
#3 /var/www/wp/wp-content/plugins/wp-openid-connect-server-rsync/src/Http/Router.php in <b>/var/www/wp/wp-content/plugins/wp-openid-connect-server-rsync/src/Overrides/OpenID/Controller/AuthorizeController.php</b> on line <b>20</b><br />
```

With this change, we generate authorize response from the implementation of `IdTokenInterface` to get the correct token since that has access to `userClaims` which we don't inside of our overridden `AuthorizeController`

I have tested the authorization flow with https://oidcdebugger.com but I am a little puzzled as to how it was even functional before this. Most likely this happened with our refactoring when diff storage layers got separated and now the same instance of the available storage layer didn't provide the access it earlier could. Still, I ask for a closer inspection of this PR.