### PR TITLE
switch to GET method when taking user consent

### DIFF
--- a/src/Http/Handlers/AuthorizeHandler.php
+++ b/src/Http/Handlers/AuthorizeHandler.php
@@ -36,7 +36,7 @@ class AuthorizeHandler extends RequestHandler {
 
 		$user = wp_get_current_user();
 		if ( $this->consent_storage->needs_consent( $user->ID ) ) {
-			if ( ! isset( $_POST['authorize'] ) || 'Authorize' !== $_POST['authorize'] ) {
+			if ( ! isset( $_REQUEST['authorize'] ) || 'Authorize' !== $_REQUEST['authorize'] ) {
 				$response->send();
 				exit;
 			}

--- a/src/Http/Handlers/AuthorizeHandler.php
+++ b/src/Http/Handlers/AuthorizeHandler.php
@@ -36,7 +36,7 @@ class AuthorizeHandler extends RequestHandler {
 
 		$user = wp_get_current_user();
 		if ( $this->consent_storage->needs_consent( $user->ID ) ) {
-			// phpcs:disable WordPress.Security.NonceVerification.Recommended We already have REST API nonce validating the user intention with this request
+			// phpcs:disable WordPress.Security.NonceVerification.Recommended -- We already have REST API nonce validating the user intention with this request
 			if ( ! isset( $_REQUEST['authorize'] ) || 'Authorize' !== $_REQUEST['authorize'] ) {
 				$response->send();
 				exit;

--- a/src/Http/Handlers/AuthorizeHandler.php
+++ b/src/Http/Handlers/AuthorizeHandler.php
@@ -22,6 +22,15 @@ class AuthorizeHandler extends RequestHandler {
 	}
 
 	public function handle( Request $request, Response $response ): Response {
+		// Our dependency bshaffer's OAuth library currently has a bug where it doesn't pick up nonce correctly
+		// if it's a POST method to the Authorize endpoint
+		// Fix has been contributed upstream but it doesn't look it would be merged anytime soon based on recent activity
+		// https://github.com/bshaffer/oauth2-server-php/pull/1032
+		// Hence, as a temporary fix, we are copying over the nonce from parsed $_POST values to parsed $_GET values in $request object here
+		if ( isset( $request->request['nonce'] ) && ! isset( $request->query['nonce'] ) ) {
+			$request->query['nonce'] = $request->request['nonce'];
+		}
+
 		if ( ! $this->server->validateAuthorizeRequest( $request, $response ) ) {
 			return $response;
 		}

--- a/src/Http/Handlers/AuthorizeHandler.php
+++ b/src/Http/Handlers/AuthorizeHandler.php
@@ -36,6 +36,7 @@ class AuthorizeHandler extends RequestHandler {
 
 		$user = wp_get_current_user();
 		if ( $this->consent_storage->needs_consent( $user->ID ) ) {
+			// phpcs:disable WordPress.Security.NonceVerification.Recommended We already have REST API nonce validating the user intention with this request
 			if ( ! isset( $_REQUEST['authorize'] ) || 'Authorize' !== $_REQUEST['authorize'] ) {
 				$response->send();
 				exit;

--- a/src/Http/Handlers/AuthorizeHandler.php
+++ b/src/Http/Handlers/AuthorizeHandler.php
@@ -36,8 +36,7 @@ class AuthorizeHandler extends RequestHandler {
 
 		$user = wp_get_current_user();
 		if ( $this->consent_storage->needs_consent( $user->ID ) ) {
-			// phpcs:disable WordPress.Security.NonceVerification.Recommended -- We already have REST API nonce validating the user intention with this request
-			if ( ! isset( $_REQUEST['authorize'] ) || 'Authorize' !== $_REQUEST['authorize'] ) {
+			if ( ! isset( $_POST['authorize'] ) || 'Authorize' !== $_POST['authorize'] ) {
 				$response->send();
 				exit;
 			}

--- a/src/Http/Handlers/AuthorizeHandler.php
+++ b/src/Http/Handlers/AuthorizeHandler.php
@@ -22,11 +22,9 @@ class AuthorizeHandler extends RequestHandler {
 	}
 
 	public function handle( Request $request, Response $response ): Response {
-		// Our dependency bshaffer's OAuth library currently has a bug where it doesn't pick up nonce correctly
-		// if it's a POST method to the Authorize endpoint
-		// Fix has been contributed upstream but it doesn't look it would be merged anytime soon based on recent activity
-		// https://github.com/bshaffer/oauth2-server-php/pull/1032
-		// Hence, as a temporary fix, we are copying over the nonce from parsed $_POST values to parsed $_GET values in $request object here
+		// Our dependency bshaffer's OAuth library currently has a bug where it doesn't pick up nonce correctly if it's a POST request to the Authorize endpoint.
+		// Fix has been contributed upstream (https://github.com/bshaffer/oauth2-server-php/pull/1032) but it doesn't look it would be merged anytime soon based on recent activity.
+		// Hence, as a temporary fix, we are copying over the nonce from parsed $_POST values to parsed $_GET values in $request object here.
 		if ( isset( $request->request['nonce'] ) && ! isset( $request->query['nonce'] ) ) {
 			$request->query['nonce'] = $request->request['nonce'];
 		}

--- a/templates/authenticate/form.php
+++ b/templates/authenticate/form.php
@@ -1,6 +1,6 @@
 <?php /** @var stdClass $data */ ?>
 
-<form method="post" action="<?php echo esc_url( $data->form_url ); ?>">
+<form method="GET" action="<?php echo esc_url( $data->form_url ); ?>">
 	<?php wp_nonce_field( 'wp_rest' ); /* The nonce will give the REST call the userdata. */ ?>
 	<?php foreach ( $data->form_fields as $key => $value ) : ?>
 		<input type="hidden" name="<?php echo esc_attr( $key ); ?>" value="<?php echo esc_attr( $value ); ?>"/>

--- a/templates/authenticate/form.php
+++ b/templates/authenticate/form.php
@@ -1,6 +1,6 @@
 <?php /** @var stdClass $data */ ?>
 
-<form method="GET" action="<?php echo esc_url( $data->form_url ); ?>">
+<form method="post" action="<?php echo esc_url( $data->form_url ); ?>">
 	<?php wp_nonce_field( 'wp_rest' ); /* The nonce will give the REST call the userdata. */ ?>
 	<?php foreach ( $data->form_fields as $key => $value ) : ?>
 		<input type="hidden" name="<?php echo esc_attr( $key ); ?>" value="<?php echo esc_attr( $value ); ?>"/>


### PR DESCRIPTION
Currently bshaffer oauth library has a bug when POST is used on AuthorizeEndpoint along with nonce (optional parameter) which fails to set the nonce in id_token

This PR switches the form submit method to `GET` when taking user consent and this fixes the issue.

Fixes #35 

The reason why this issue would only break for new users is because of sticky consent functionality the parameters would get passed as GET parameters, hence not uncovering the issue with bshaffer oauth library.

Additionally, I have also already created a [PR](https://github.com/bshaffer/oauth2-server-php/pull/1032) to the library with the fix.