### PR TITLE
make consent storage client specific

### DIFF
--- a/src/Http/Handlers/AuthenticateHandler.php
+++ b/src/Http/Handlers/AuthenticateHandler.php
@@ -32,7 +32,8 @@ class AuthenticateHandler extends RequestHandler {
 			auth_redirect();
 		}
 
-		if ( ! $this->consent_storage->needs_consent( get_current_user_id() ) ) {
+		$client_id = $request->query['client_id'];
+		if ( ! $this->consent_storage->needs_consent( get_current_user_id(), $client_id ) ) {
 			$this->redirect( $request );
 			// TODO: return response instead of exiting.
 			exit;

--- a/src/Http/Handlers/AuthorizeHandler.php
+++ b/src/Http/Handlers/AuthorizeHandler.php
@@ -42,13 +42,15 @@ class AuthorizeHandler extends RequestHandler {
 		}
 
 		$user = wp_get_current_user();
-		if ( $this->consent_storage->needs_consent( $user->ID ) ) {
+
+		$client_id = $request->request['client_id'];
+		if ( $this->consent_storage->needs_consent( $user->ID, $client_id ) ) {
 			if ( ! isset( $_POST['authorize'] ) || 'Authorize' !== $_POST['authorize'] ) {
 				$response->send();
 				exit;
 			}
 
-			$this->consent_storage->update_timestamp( $user->ID );
+			$this->consent_storage->update_timestamp( $user->ID, $client_id );
 		}
 
 		return $this->server->handleAuthorizeRequest( $request, $response, true, $user->user_login );

--- a/src/Storage/ConsentStorage.php
+++ b/src/Storage/ConsentStorage.php
@@ -3,18 +3,22 @@
 namespace OpenIDConnectServer\Storage;
 
 const STICKY_CONSENT_DURATION = 7 * DAY_IN_SECONDS;
-const META_KEY                = 'oidc_consent_timestamp';
+const META_KEY_PREFIX         = 'oidc_consent_timestamp';
 
 class ConsentStorage {
-	public function needs_consent( $user_id ): bool {
-		$consent_timestamp = absint( get_user_meta( $user_id, META_KEY, true ) );
+	private function get_meta_key( $client_id ) : string {
+		return META_KEY_PREFIX . '_' . $client_id;
+	}
+
+	public function needs_consent( $user_id, $client_id ): bool {
+		$consent_timestamp = absint( get_user_meta( $user_id, $this->get_meta_key( $client_id ), true ) );
 
 		$past_consent_expiry = time() > ( $consent_timestamp + ( STICKY_CONSENT_DURATION ) );
 
 		return empty( $consent_timestamp ) || $past_consent_expiry;
 	}
 
-	public function update_timestamp( $user_id ) {
-		update_user_meta( $user_id, META_KEY, time() );
+	public function update_timestamp( $user_id, $client_id ) {
+		update_user_meta( $user_id, $this->get_meta_key( $client_id ), time() );
 	}
 }


### PR DESCRIPTION
This PR makes the client storage specific to client by utilising client_id as the part of meta key while storing in usermeta.

fixes #37 