### PR TITLE
replace need of defining oidc_clients() with a filter as a way of configuring oidc clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,10 @@ define( 'OIDC_PRIVATE_KEY', file_get_contents( '/web-inaccessible/private.key' )
 
 ### Define the clients
 
-Define your clients like so (this needs to be added before WordPress loads):
+Define your clients by adding a filter to `oidc_registered_clients` in a separate plugin file or `functions.php` of your theme or in a MU-plugin like:
 ```
-function oidc_clients() {
+add_filter( 'oidc_registered_clients', 'my_oidc_clients' );
+function my_oidc_clients() {
 	return array(
 		'client_id_random_string' => array(
 			'name' => 'The name of the Client',

--- a/src/SiteStatusTests.php
+++ b/src/SiteStatusTests.php
@@ -111,7 +111,7 @@ class SiteStatusTests {
 	}
 
 	public function site_status_test_clients(): array {
-		$clients = function_exists( '\oidc_clients' ) ? \oidc_clients() : array();
+		$clients = apply_filters( 'oidc_registered_clients', array() );
 		if ( empty( $clients ) ) {
 			$label  = __( 'No clients have been defined.', 'wp-openid-connect-server' );
 			$status = 'critical';

--- a/wp-openid-connect-server.php
+++ b/wp-openid-connect-server.php
@@ -23,7 +23,7 @@ add_action(
 			return;
 		}
 
-		$clients = function_exists( '\oidc_clients' ) ? \oidc_clients() : array();
+		$clients = apply_filters( 'oidc_registered_clients', array() ); // Currently the only way to add clients is to use this filter
 		new OpenIDConnectServer( OIDC_PUBLIC_KEY, OIDC_PRIVATE_KEY, $clients );
 	}
 );

--- a/wp-openid-connect-server.php
+++ b/wp-openid-connect-server.php
@@ -23,7 +23,7 @@ add_action(
 			return;
 		}
 
-		$clients = apply_filters( 'oidc_registered_clients', array() ); // Currently the only way to add clients is to use this filter
+		$clients = apply_filters( 'oidc_registered_clients', array() ); // Currently the only way to add clients is to use this filter.
 		new OpenIDConnectServer( OIDC_PUBLIC_KEY, OIDC_PRIVATE_KEY, $clients );
 	}
 );


### PR DESCRIPTION
This PR removes the need of defining `oidc_clients()` as the means of defining OIDC clients and makes `oidc_registered_clients` filter available, using which OIDC clients can be defined from other places in code. Updates the readme as well.

Fixes #39 

Requires #41 to be merged first though.