### PR TITLE
Fix client_id inaccessible with POST on Authorize handler

### DIFF
--- a/src/Http/Handlers/AuthenticateHandler.php
+++ b/src/Http/Handlers/AuthenticateHandler.php
@@ -32,7 +32,7 @@ class AuthenticateHandler extends RequestHandler {
 			auth_redirect();
 		}
 
-		$client_id = $request->query['client_id'];
+		$client_id = $request->query( 'client_id' );
 		if ( ! $this->consent_storage->needs_consent( get_current_user_id(), $client_id ) ) {
 			$this->redirect( $request );
 			// TODO: return response instead of exiting.

--- a/src/Http/Handlers/AuthorizeHandler.php
+++ b/src/Http/Handlers/AuthorizeHandler.php
@@ -43,7 +43,7 @@ class AuthorizeHandler extends RequestHandler {
 
 		$user = wp_get_current_user();
 
-		$client_id = $request->request['client_id'];
+		$client_id = $request->query( 'client_id', $request->request( 'client_id' ) );
 		if ( $this->consent_storage->needs_consent( $user->ID, $client_id ) ) {
 			if ( ! isset( $_POST['authorize'] ) || 'Authorize' !== $_POST['authorize'] ) {
 				$response->send();


### PR DESCRIPTION
This PR fixes `client_id` being inaccessible with POST on Authorize handler for the purpose of client specific consent storage.

When `client_id` is not available in $_GET, it attempts to get it from $_POST since that's defined as a default value.