### PR TITLE
Change authorization code storage to use usermeta instead of taxonomy

### DIFF
--- a/src/Storage/AuthorizationCodeStorage.php
+++ b/src/Storage/AuthorizationCodeStorage.php
@@ -5,120 +5,84 @@ namespace OpenIDConnectServer\Storage;
 use OAuth2\OpenID\Storage\AuthorizationCodeInterface;
 
 class AuthorizationCodeStorage implements AuthorizationCodeInterface {
-	const TAXONOMY = 'oidc-authorization-code';
+	const META_KEY_PREFIX = 'oidc';
 
 	private static array $authorization_code_data = array(
 		'code'         => 'string', // authorization code.
 		'client_id'    => 'string', // client identifier.
-		'user_login'   => 'string', // The WordPress user id.
 		'redirect_uri' => 'string', // redirect URI.
 		'expires'      => 'int',    // expires as unix timestamp.
 		'scope'        => 'string', // scope as space-separated string.
 		'id_token'     => 'string', // The OpenID Connect id_token.
 	);
 
-	public function __construct() {
-		// Store the authorization codes in a taxonomy.
-		register_taxonomy( self::TAXONOMY, null );
-		foreach ( self::$authorization_code_data as $key => $type ) {
-			register_term_meta(
-				self::TAXONOMY,
-				$key,
-				array(
-					'type'              => $type,
-					'single'            => true,
-					'sanitize_callback' => array( __CLASS__, 'sanitize_' . $key ),
-				)
-			);
-		}
-	}
-
-	public static function sanitize_string_length( $string, $length ) {
-		return substr( $string, 0, $length );
-	}
-
-	public static function sanitize_code( $code ) {
-		return self::sanitize_string_length( $code, 40 );
-	}
-
-	public static function sanitize_client_id( $client_id ) {
-		return self::sanitize_string_length( $client_id, 200 );
-	}
-
-	public static function sanitize_redirect_uri( $redirect_uri ) {
-		return self::sanitize_string_length( $redirect_uri, 2000 );
-	}
-
-	public static function sanitize_scope( $scope ) {
-		return self::sanitize_string_length( $scope, 100 );
-	}
-
-	public static function sanitize_id_token( $id_token ) {
-		return self::sanitize_string_length( $id_token, 2000 );
-	}
-
-	public static function sanitize_user_login( $user_login ) {
-		return self::sanitize_string_length( $user_login, 60 );
-	}
-
-	public static function sanitize_expires( $expires ) {
-		return intval( $expires );
-	}
-
 	public function getAuthorizationCode( $code ) {
-		$term = get_term_by( 'slug', $code, self::TAXONOMY );
-
-		if ( $term ) {
-			$authorization_code = array();
-			foreach (
-				array(
-					'client_id'    => 'client_id',
-					'user_id'      => 'user_login',
-					'expires'      => 'expires',
-					'redirect_uri' => 'redirect_uri',
-					'scope'        => 'scope',
-					'id_token'     => 'id_token',
-				) as $key => $meta_key
-			) {
-				$authorization_code[ $key ] = get_term_meta( $term->term_id, $meta_key, true );
-			}
-
-			return $authorization_code;
+		if ( empty( $code ) ) {
+			return null;
 		}
 
-		return null;
+		$users = get_users( array(
+			'meta_key'   => self::META_KEY_PREFIX . '_code',
+			'meta_value' => $code,
+		) );
+
+		if ( empty( $users ) ) {
+			return null;
+		}
+
+		$user    = $users[0];
+		$user_id = absint( $user->ID );
+
+		$authorization_code = array(
+			'user_id' => $user->user_login
+		);
+		foreach ( array_keys( self::$authorization_code_data ) as $key ) {
+			$meta_key                   = self::META_KEY_PREFIX . '_' . $key;
+			$authorization_code[ $key ] = get_user_meta( $user_id, $meta_key, true );
+		}
+
+		return $authorization_code;
 	}
 
-	public function setAuthorizationCode( $code, $client_id, $user_login, $redirect_uri, $expires, $scope = null, $id_token = null ) {
-		if ( $code ) {
-			$this->expireAuthorizationCode( $code );
+	public function setAuthorizationCode( $code, $client_id, $user_id, $redirect_uri, $expires, $scope = null, $id_token = null ) {
+		if ( empty( $code ) ) {
+			return;
+		}
 
-			$term = wp_insert_term( $code, self::TAXONOMY );
-			if ( is_wp_error( $term ) || ! isset( $term['term_id'] ) ) {
-				status_header( 500 );
-				exit;
-			}
+		$user = get_user_by( 'login', $user_id ); // We have chosen WordPress' user_login as the user identifier for OIDC context
 
-			foreach (
-				array(
-					'client_id'    => $client_id,
-					'user_login'   => $user_login,
-					'redirect_uri' => $redirect_uri,
-					'expires'      => $expires,
-					'scope'        => $scope,
-					'id_token'     => $id_token,
-				) as $key => $value
-			) {
-				add_term_meta( $term['term_id'], $key, $value );
+		if ( $user ) {
+			foreach ( self::$authorization_code_data as $key => $data_type ) {
+				if ( $data_type === 'int' ) {
+					$value = absint( $$key );
+				} else {
+					$value = sanitize_text_field( $$key );
+				}
+				$meta_key = self::META_KEY_PREFIX . '_' . $key;
+				update_user_meta( $user->ID, $meta_key, $value );
 			}
 		}
 	}
 
 	public function expireAuthorizationCode( $code ) {
-		$term = get_term_by( 'slug', $code, self::TAXONOMY );
+		if ( empty( $code ) ) {
+			return;
+		}
 
-		if ( $term ) {
-			wp_delete_term( $term->term_id, self::TAXONOMY );
+		$users = get_users( array(
+			'meta_key'   => self::META_KEY_PREFIX . '_code',
+			'meta_value' => $code,
+			'fields'     => 'ID',
+		) );
+
+		if ( empty( $users ) ) {
+			return;
+		}
+
+		$user_id = absint( $users[0] );
+
+		foreach ( array_keys( self::$authorization_code_data ) as $meta_key ) {
+			delete_user_meta( $user_id, $meta_key );
 		}
 	}
 }

--- a/src/Storage/AuthorizationCodeStorage.php
+++ b/src/Storage/AuthorizationCodeStorage.php
@@ -23,9 +23,10 @@ class AuthorizationCodeStorage implements AuthorizationCodeInterface {
 			return null;
 		}
 
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery phpcs: WordPress.DB.DirectDatabaseQuery.NoCaching
 		$meta_row = $wpdb->get_row(
 			$wpdb->prepare(
-				"SELECT user_id, meta_key FROM $wpdb->usermeta WHERE meta_key LIKE '%s';",
+				"SELECT user_id, meta_key FROM $wpdb->usermeta WHERE meta_key LIKE %s;",
 				'%' . $wpdb->esc_like( $code ),
 			)
 		);
@@ -46,7 +47,7 @@ class AuthorizationCodeStorage implements AuthorizationCodeInterface {
 			return null;
 		}
 
-		$user_id = $meta['user_id'];
+		$user_id   = $meta['user_id'];
 		$client_id = $meta['client_id'];
 
 		$authorization_code = array(
@@ -59,7 +60,7 @@ class AuthorizationCodeStorage implements AuthorizationCodeInterface {
 				continue;
 			}
 
-			$meta_key = self::META_KEY_PREFIX . '_' . $client_id . '_' . $key;
+			$meta_key                   = self::META_KEY_PREFIX . '_' . $client_id . '_' . $key;
 			$authorization_code[ $key ] = get_user_meta( $user_id, $meta_key, true );
 		}
 
@@ -82,7 +83,7 @@ class AuthorizationCodeStorage implements AuthorizationCodeInterface {
 				}
 
 				if ( 'code' === $key ) {
-					// store code in meta_key itself, so that SQL query is efficient since meta_key has index defined on it
+					// store code in meta_key itself, so that SQL query is efficient since meta_key has index defined on it.
 					$meta_key = self::META_KEY_PREFIX . '_' . $client_id . '_' . $key . '_' . $code;
 				} else {
 					$meta_key = self::META_KEY_PREFIX . '_' . $client_id . '_' . $key;
@@ -99,7 +100,7 @@ class AuthorizationCodeStorage implements AuthorizationCodeInterface {
 			return null;
 		}
 
-		$user_id = $meta['user_id'];
+		$user_id   = $meta['user_id'];
 		$client_id = $meta['client_id'];
 
 		foreach ( array_keys( self::$authorization_code_data ) as $key ) {

--- a/src/Storage/AuthorizationCodeStorage.php
+++ b/src/Storage/AuthorizationCodeStorage.php
@@ -23,7 +23,7 @@ class AuthorizationCodeStorage implements AuthorizationCodeInterface {
 			return null;
 		}
 
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery phpcs: WordPress.DB.DirectDatabaseQuery.NoCaching
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 		$meta_row = $wpdb->get_row(
 			$wpdb->prepare(
 				"SELECT user_id, meta_key FROM $wpdb->usermeta WHERE meta_key LIKE %s;",

--- a/src/Storage/AuthorizationCodeStorage.php
+++ b/src/Storage/AuthorizationCodeStorage.php
@@ -20,6 +20,7 @@ class AuthorizationCodeStorage implements AuthorizationCodeInterface {
 			return null;
 		}
 
+		// @akirk: get_users() is better than a direct db query: in a Multiuser installation, it adds a query that checks whether the user is a member of the blog.
 		$users = get_users(
 			array(
 				'number'       => 1,

--- a/src/Storage/AuthorizationCodeStorage.php
+++ b/src/Storage/AuthorizationCodeStorage.php
@@ -21,10 +21,12 @@ class AuthorizationCodeStorage implements AuthorizationCodeInterface {
 			return null;
 		}
 
-		$users = get_users( array(
-			'meta_key'   => self::META_KEY_PREFIX . '_code',
-			'meta_value' => $code,
-		) );
+		$users = get_users(
+			array(
+				'meta_key'   => self::META_KEY_PREFIX . '_code', // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+				'meta_value' => $code, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
+			)
+		);
 
 		if ( empty( $users ) ) {
 			return null;
@@ -33,9 +35,7 @@ class AuthorizationCodeStorage implements AuthorizationCodeInterface {
 		$user    = $users[0];
 		$user_id = absint( $user->ID );
 
-		$authorization_code = array(
-			'user_id' => $user->user_login
-		);
+		$authorization_code = array( 'user_id' => $user->user_login );
 		foreach ( array_keys( self::$authorization_code_data ) as $key ) {
 			$meta_key                   = self::META_KEY_PREFIX . '_' . $key;
 			$authorization_code[ $key ] = get_user_meta( $user_id, $meta_key, true );
@@ -49,11 +49,11 @@ class AuthorizationCodeStorage implements AuthorizationCodeInterface {
 			return;
 		}
 
-		$user = get_user_by( 'login', $user_id ); // We have chosen WordPress' user_login as the user identifier for OIDC context
+		$user = get_user_by( 'login', $user_id ); // We have chosen WordPress' user_login as the user identifier for OIDC context.
 
 		if ( $user ) {
 			foreach ( self::$authorization_code_data as $key => $data_type ) {
-				if ( $data_type === 'int' ) {
+				if ( 'int' === $data_type ) {
 					$value = absint( $$key );
 				} else {
 					$value = sanitize_text_field( $$key );
@@ -69,11 +69,13 @@ class AuthorizationCodeStorage implements AuthorizationCodeInterface {
 			return;
 		}
 
-		$users = get_users( array(
-			'meta_key'   => self::META_KEY_PREFIX . '_code',
-			'meta_value' => $code,
-			'fields'     => 'ID',
-		) );
+		$users = get_users(
+			array(
+				'meta_key'   => self::META_KEY_PREFIX . '_code', // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+				'meta_value' => $code, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
+				'fields'     => 'ID',
+			)
+		);
 
 		if ( empty( $users ) ) {
 			return;

--- a/src/Storage/AuthorizationCodeStorage.php
+++ b/src/Storage/AuthorizationCodeStorage.php
@@ -23,6 +23,7 @@ class AuthorizationCodeStorage implements AuthorizationCodeInterface {
 
 		$users = get_users(
 			array(
+				'number'     => 1,
 				'meta_key'   => self::META_KEY_PREFIX . '_code', // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
 				'meta_value' => $code, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
 			)
@@ -71,6 +72,7 @@ class AuthorizationCodeStorage implements AuthorizationCodeInterface {
 
 		$users = get_users(
 			array(
+				'number'     => 1,
 				'meta_key'   => self::META_KEY_PREFIX . '_code', // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
 				'meta_value' => $code, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
 				'fields'     => 'ID',

--- a/src/Storage/AuthorizationCodeStorage.php
+++ b/src/Storage/AuthorizationCodeStorage.php
@@ -22,8 +22,11 @@ class AuthorizationCodeStorage implements AuthorizationCodeInterface {
 
 		$users = get_users(
 			array(
-				'number'     => 1,
-				'meta_key'   => self::META_KEY_PREFIX . '_client_id_' . $code, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key see
+				'number'       => 1,
+				// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+				'meta_key'     => self::META_KEY_PREFIX . '_client_id_' . $code,
+				// Using a meta_key EXISTS query is not slow, see https://github.com/WordPress/WordPress-Coding-Standards/issues/1871.
+				'meta_compare' => 'EXISTS',
 			)
 		);
 
@@ -41,15 +44,15 @@ class AuthorizationCodeStorage implements AuthorizationCodeInterface {
 		}
 
 		$authorization_code = array(
-			'user_id'   => $user_id,
-			'code'      => $code,
+			'user_id' => $user_id,
+			'code'    => $code,
 		);
 
 		foreach ( array_keys( self::$authorization_code_data ) as $key ) {
 			$authorization_code[ $key ] = get_user_meta( $user_id, self::META_KEY_PREFIX . '_' . $key . '_' . $code, true );
 		}
 
-		if ( $authorization_code["expires"] < time() ) {
+		if ( $authorization_code['expires'] < time() ) {
 			// Remove it right now to avoid cleanup work later.
 			$this->expireAuthorizationCode( $code );
 		}

--- a/src/Storage/AuthorizationCodeStorage.php
+++ b/src/Storage/AuthorizationCodeStorage.php
@@ -48,14 +48,8 @@ class AuthorizationCodeStorage implements AuthorizationCodeInterface {
 			'user_id' => $user_id,
 			'code'    => $code,
 		);
-
 		foreach ( array_keys( self::$authorization_code_data ) as $key ) {
 			$authorization_code[ $key ] = get_user_meta( $user_id, self::META_KEY_PREFIX . '_' . $key . '_' . $code, true );
-		}
-
-		if ( $authorization_code['expires'] < time() ) {
-			// Remove it right now to avoid cleanup work later.
-			$this->expireAuthorizationCode( $code );
 		}
 
 		return $authorization_code;

--- a/src/Storage/ConsentStorage.php
+++ b/src/Storage/ConsentStorage.php
@@ -3,10 +3,11 @@
 namespace OpenIDConnectServer\Storage;
 
 const STICKY_CONSENT_DURATION = 7 * DAY_IN_SECONDS;
+const META_KEY_PREFIX         = 'oidc_consent_timestamp';
 
 class ConsentStorage {
 	private function get_meta_key( $client_id ) : string {
-		return 'oidc_' . $client_id . '_consent_timestamp';
+		return META_KEY_PREFIX . '_' . $client_id;
 	}
 
 	public function needs_consent( $user_id, $client_id ): bool {

--- a/src/Storage/ConsentStorage.php
+++ b/src/Storage/ConsentStorage.php
@@ -3,11 +3,10 @@
 namespace OpenIDConnectServer\Storage;
 
 const STICKY_CONSENT_DURATION = 7 * DAY_IN_SECONDS;
-const META_KEY_PREFIX         = 'oidc_consent_timestamp';
 
 class ConsentStorage {
 	private function get_meta_key( $client_id ) : string {
-		return META_KEY_PREFIX . '_' . $client_id;
+		return 'oidc_' . $client_id . 'consent_timestamp';
 	}
 
 	public function needs_consent( $user_id, $client_id ): bool {

--- a/src/Storage/ConsentStorage.php
+++ b/src/Storage/ConsentStorage.php
@@ -6,7 +6,7 @@ const STICKY_CONSENT_DURATION = 7 * DAY_IN_SECONDS;
 
 class ConsentStorage {
 	private function get_meta_key( $client_id ) : string {
-		return 'oidc_' . $client_id . 'consent_timestamp';
+		return 'oidc_' . $client_id . '_consent_timestamp';
 	}
 
 	public function needs_consent( $user_id, $client_id ): bool {


### PR DESCRIPTION
This PR changes AuthorizationCodeStorage to be based on usermeta so that there is no risk of authorization codes being exposed on REST API since by default usermeta fields are not exposed on REST API unless explicitly registered to do so.

Seems like the safest approach instead of relying on controlling taxonomies to not be accidentally exposed.

Fixes #26 