### PR TITLE
Clean up old auth codes sitting in database because of interrupted/abandoned OAuth flows

### DIFF
--- a/src/OpenIDConnectServer.php
+++ b/src/OpenIDConnectServer.php
@@ -56,7 +56,7 @@ class OpenIDConnectServer {
 		$this->router->add_route( '.well-known/openid-configuration', new ConfigurationHandler() );
 		add_action( 'login_form_openid-authenticate', array( $this, 'authenticate_handler' ) );
 
-		// Cleanup
+		// Cleanup.
 		$this->setup_cleanup_routine();
 	}
 

--- a/src/OpenIDConnectServer.php
+++ b/src/OpenIDConnectServer.php
@@ -55,6 +55,9 @@ class OpenIDConnectServer {
 		$this->router->add_route( '.well-known/jwks.json', new WebKeySetsHandler( $this->public_key ) );
 		$this->router->add_route( '.well-known/openid-configuration', new ConfigurationHandler() );
 		add_action( 'login_form_openid-authenticate', array( $this, 'authenticate_handler' ) );
+
+		// Cleanup
+		$this->setup_cleanup_routine();
 	}
 
 	public function authenticate_handler() {
@@ -64,5 +67,11 @@ class OpenIDConnectServer {
 		$authenticate_handler = new AuthenticateHandler( $this->consent_storage, $this->clients );
 		$authenticate_handler->handle( $request, $response );
 		exit;
+	}
+
+	public function setup_cleanup_routine() {
+		if ( ! wp_next_scheduled( 'oidc_cron_hook' ) ) {
+			wp_schedule_event( time(), 'weekly', 'oidc_cron_hook' );
+		}
 	}
 }

--- a/src/OpenIDConnectServer.php
+++ b/src/OpenIDConnectServer.php
@@ -57,7 +57,7 @@ class OpenIDConnectServer {
 		add_action( 'login_form_openid-authenticate', array( $this, 'authenticate_handler' ) );
 
 		// Cleanup.
-		$this->setup_cleanup_routine();
+		$this->setup_cron_hook();
 	}
 
 	public function authenticate_handler() {
@@ -69,7 +69,7 @@ class OpenIDConnectServer {
 		exit;
 	}
 
-	public function setup_cleanup_routine() {
+	public function setup_cron_hook() {
 		if ( ! wp_next_scheduled( 'oidc_cron_hook' ) ) {
 			wp_schedule_event( time(), 'weekly', 'oidc_cron_hook' );
 		}

--- a/src/Storage/AuthorizationCodeStorage.php
+++ b/src/Storage/AuthorizationCodeStorage.php
@@ -105,12 +105,8 @@ class AuthorizationCodeStorage implements AuthorizationCodeInterface {
 		foreach ( $data as $row ) {
 			$expiry = absint( $row->meta_value );
 			$code   = substr( $row->meta_key, strlen( 'oidc_expires_' ) );
-
-			// wait for an hour past expiry, to offer a chance at debug.
-			if ( time() > $expiry + 3600 ) {
-				foreach ( array_keys( self::$authorization_code_data ) as $key ) {
-					delete_user_meta( $row->user_id, self::META_KEY_PREFIX . '_' . $key . '_' . $code );
-				}
+			foreach ( array_keys( self::$authorization_code_data ) as $key ) {
+				delete_user_meta( $row->user_id, self::META_KEY_PREFIX . '_' . $key . '_' . $code );
 			}
 		}
 	}

--- a/src/Storage/AuthorizationCodeStorage.php
+++ b/src/Storage/AuthorizationCodeStorage.php
@@ -104,7 +104,7 @@ class AuthorizationCodeStorage implements AuthorizationCodeInterface {
 
 		foreach ( $data as $row ) {
 			$expiry = absint( $row->meta_value );
-			$code   = str_replace( 'oidc_expires_', '', $row->meta_key );
+			$code   = substr( $row->meta_key, strlen( 'oidc_expires_' ) );
 
 			// wait for an hour past expiry, to offer a chance at debug.
 			if ( time() > $expiry + 3600 ) {

--- a/src/Storage/AuthorizationCodeStorage.php
+++ b/src/Storage/AuthorizationCodeStorage.php
@@ -109,7 +109,7 @@ class AuthorizationCodeStorage implements AuthorizationCodeInterface {
 		}
 
 		foreach ( $data as $row ) {
-			$code   = substr( $row->meta_key, strlen( 'oidc_expires_' ) );
+			$code = substr( $row->meta_key, strlen( 'oidc_expires_' ) );
 			foreach ( array_keys( self::$authorization_code_data ) as $key ) {
 				delete_user_meta( $row->user_id, self::META_KEY_PREFIX . '_' . $key . '_' . $code );
 			}

--- a/src/Storage/AuthorizationCodeStorage.php
+++ b/src/Storage/AuthorizationCodeStorage.php
@@ -97,7 +97,13 @@ class AuthorizationCodeStorage implements AuthorizationCodeInterface {
 		global $wpdb;
 
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
-		$data = $wpdb->get_results( $wpdb->prepare( "SELECT user_id, meta_key FROM $wpdb->usermeta WHERE meta_key LIKE 'oidc_expires_%' AND meta_value < %d", time() - 3600 ) );
+		$data = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT user_id, meta_key FROM $wpdb->usermeta WHERE meta_key LIKE %s AND meta_value < %d",
+				'oidc_expires_%',
+				time() - 3600 // wait for an hour past expiry, to offer a chance at debug.
+			)
+		);
 		if ( empty( $data ) ) {
 			return;
 		}

--- a/src/Storage/AuthorizationCodeStorage.php
+++ b/src/Storage/AuthorizationCodeStorage.php
@@ -97,7 +97,7 @@ class AuthorizationCodeStorage implements AuthorizationCodeInterface {
 		global $wpdb;
 
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
-		$data = $wpdb->get_results( "SELECT user_id, meta_key, meta_value FROM $wpdb->usermeta WHERE meta_key LIKE 'oidc_expires_%';" );
+		$data = $wpdb->get_results( $wpdb->prepare( "SELECT user_id, meta_key FROM $wpdb->usermeta WHERE meta_key LIKE 'oidc_expires_%' AND meta_value < %d", time() - 3600 ) );
 		if ( empty( $data ) ) {
 			return;
 		}

--- a/src/Storage/AuthorizationCodeStorage.php
+++ b/src/Storage/AuthorizationCodeStorage.php
@@ -90,10 +90,13 @@ class AuthorizationCodeStorage implements AuthorizationCodeInterface {
 		}
 	}
 
-	// This function cleans up auth codes that are sitting in the database because of interrupted/abandoned OAuth flows
+	/**
+	 * This function cleans up auth codes that are sitting in the database because of interrupted/abandoned OAuth flows.
+	 */
 	public function cleanupOldCodes() {
 		global $wpdb;
 
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 		$data = $wpdb->get_results( "SELECT user_id, meta_key, meta_value FROM $wpdb->usermeta WHERE meta_key LIKE 'oidc_expires_%';" );
 		if ( empty( $data ) ) {
 			return;
@@ -101,7 +104,7 @@ class AuthorizationCodeStorage implements AuthorizationCodeInterface {
 
 		foreach ( $data as $row ) {
 			$expiry = absint( $row->meta_value );
-			$code = str_replace( 'oidc_expires_', '', $row->meta_key );
+			$code   = str_replace( 'oidc_expires_', '', $row->meta_key );
 
 			// wait for an hour past expiry, to offer a chance at debug.
 			if ( time() > $expiry + 3600 ) {

--- a/src/Storage/AuthorizationCodeStorage.php
+++ b/src/Storage/AuthorizationCodeStorage.php
@@ -109,7 +109,6 @@ class AuthorizationCodeStorage implements AuthorizationCodeInterface {
 		}
 
 		foreach ( $data as $row ) {
-			$expiry = absint( $row->meta_value );
 			$code   = substr( $row->meta_key, strlen( 'oidc_expires_' ) );
 			foreach ( array_keys( self::$authorization_code_data ) as $key ) {
 				delete_user_meta( $row->user_id, self::META_KEY_PREFIX . '_' . $key . '_' . $code );


### PR DESCRIPTION
This PR registers a weekly cron hook and cleans up codes that are past an hour of their expiration.

fixes #34 