### PR TITLE
Improve the behavior for multisites with a separate login server

### DIFF
--- a/src/Http/Handlers/AuthorizeHandler.php
+++ b/src/Http/Handlers/AuthorizeHandler.php
@@ -37,7 +37,7 @@ class AuthorizeHandler extends RequestHandler {
 		if ( ! is_user_logged_in() || ! current_user_can( apply_filters( 'oidc_minimal_capability', OIDC_DEFAULT_MINIMAL_CAPABILITY ) ) ) {
 			// This is handled by a hook in wp-login.php which will display a form asking the user to consent.
 			// TODO: Redirect with $response->setRedirect().
-			wp_safe_redirect( add_query_arg( $request->getAllQueryParameters(), home_url( '/wp-login.php?action=openid-authenticate' ) ) );
+			wp_safe_redirect( add_query_arg( array_map( 'rawurlencode', array_merge( $request->getAllQueryParameters(), array( 'action' => 'openid-authenticate' ) ), wp_login_url() ) ) );
 			exit;
 		}
 

--- a/src/Http/Handlers/AuthorizeHandler.php
+++ b/src/Http/Handlers/AuthorizeHandler.php
@@ -37,7 +37,7 @@ class AuthorizeHandler extends RequestHandler {
 		if ( ! is_user_logged_in() || ! current_user_can( apply_filters( 'oidc_minimal_capability', OIDC_DEFAULT_MINIMAL_CAPABILITY ) ) ) {
 			// This is handled by a hook in wp-login.php which will display a form asking the user to consent.
 			// TODO: Redirect with $response->setRedirect().
-			wp_safe_redirect( add_query_arg( array_map( 'rawurlencode', array_merge( $request->getAllQueryParameters(), array( 'action' => 'openid-authenticate' ) ), wp_login_url() ) ) );
+			wp_safe_redirect( add_query_arg( array_map( 'rawurlencode', array_merge( $request->getAllQueryParameters(), array( 'action' => 'openid-authenticate' ) ) ), wp_login_url() ) );
 			exit;
 		}
 

--- a/src/Storage/AuthorizationCodeStorage.php
+++ b/src/Storage/AuthorizationCodeStorage.php
@@ -24,9 +24,9 @@ class AuthorizationCodeStorage implements AuthorizationCodeInterface {
 			return null;
 		}
 
-		// @akirk: get_users() is better than a direct db query: in a Multiuser installation, it adds a query that checks whether the user is a member of the blog.
 		$users = get_users(
-			apply_filters( 'oidc_authorization_code_query',
+			apply_filters(
+				'oidc_authorization_code_query',
 				array(
 					'number'       => 1,
 					// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key

--- a/src/Storage/AuthorizationCodeStorage.php
+++ b/src/Storage/AuthorizationCodeStorage.php
@@ -25,15 +25,16 @@ class AuthorizationCodeStorage implements AuthorizationCodeInterface {
 		}
 
 		$users = get_users(
-			apply_filters(
-				'oidc_authorization_code_query',
-				array(
-					'number'       => 1,
-					// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
-					'meta_key'     => self::META_KEY_PREFIX . '_client_id_' . $code,
-					// Using a meta_key EXISTS query is not slow, see https://github.com/WordPress/WordPress-Coding-Standards/issues/1871.
-					'meta_compare' => 'EXISTS',
-				)
+			array(
+				'number'       => 1,
+				// Specifying blog_id does nothing for non-MultiSite installs. But for MultiSite installs, it allows you
+				// to customize users of which site is supposed to be available for whatever sites
+				// this plugin is meant to be activated on
+				'blog_id'      => apply_filters( 'oidc_auth_code_storage_blog_id', get_current_blog_id() ),
+				// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+				'meta_key'     => self::META_KEY_PREFIX . '_client_id_' . $code,
+				// Using a meta_key EXISTS query is not slow, see https://github.com/WordPress/WordPress-Coding-Standards/issues/1871.
+				'meta_compare' => 'EXISTS',
 			)
 		);
 

--- a/src/Storage/AuthorizationCodeStorage.php
+++ b/src/Storage/AuthorizationCodeStorage.php
@@ -29,7 +29,7 @@ class AuthorizationCodeStorage implements AuthorizationCodeInterface {
 				'number'       => 1,
 				// Specifying blog_id does nothing for non-MultiSite installs. But for MultiSite installs, it allows you
 				// to customize users of which site is supposed to be available for whatever sites
-				// this plugin is meant to be activated on
+				// this plugin is meant to be activated on.
 				'blog_id'      => apply_filters( 'oidc_auth_code_storage_blog_id', get_current_blog_id() ),
 				// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
 				'meta_key'     => self::META_KEY_PREFIX . '_client_id_' . $code,

--- a/src/Storage/AuthorizationCodeStorage.php
+++ b/src/Storage/AuthorizationCodeStorage.php
@@ -26,12 +26,14 @@ class AuthorizationCodeStorage implements AuthorizationCodeInterface {
 
 		// @akirk: get_users() is better than a direct db query: in a Multiuser installation, it adds a query that checks whether the user is a member of the blog.
 		$users = get_users(
-			array(
-				'number'       => 1,
-				// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
-				'meta_key'     => self::META_KEY_PREFIX . '_client_id_' . $code,
-				// Using a meta_key EXISTS query is not slow, see https://github.com/WordPress/WordPress-Coding-Standards/issues/1871.
-				'meta_compare' => 'EXISTS',
+			apply_filters( 'oidc_authorization_code_query',
+				array(
+					'number'       => 1,
+					// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+					'meta_key'     => self::META_KEY_PREFIX . '_client_id_' . $code,
+					// Using a meta_key EXISTS query is not slow, see https://github.com/WordPress/WordPress-Coding-Standards/issues/1871.
+					'meta_compare' => 'EXISTS',
+				)
 			)
 		);
 


### PR DESCRIPTION
Fixes #50, #51.

Multisites can now use this snippet to remove the requirement for the user to be a member of the queried site:
```
add_filter( 'oidc_auth_code_storage_blog_id', function( $q ) {
    return 0;
} );
```