### PR TITLE
update plugin header + readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 Use OpenID Connect to log in to other webservices using your own WordPress.
 
-**Contributors:** akirk, ashfame, psrpinto
-**Tags:** oidc, openid, connect, server
-**Requires at least:** 5.0
-**Tested up to:** 6.1
-**Requires PHP:** 7.1
-**License:** [GPLv2 or later](http://www.gnu.org/licenses/gpl-2.0.html)
-**Stable tag:** trunk
+**Contributors:** automattic, akirk, ashfame, psrpinto
+**Tags:** oidc, oauth, openid, openid connect, oauth server
+**Requires at least:** 6.0
+**Tested up to:** 6.0
+**Requires PHP:** 7.4
+**License:** [GPLv2](http://www.gnu.org/licenses/gpl-2.0.html)
+**Stable tag:** 1.0
 **GitHub Plugin URI:** https://github.com/Automattic/wp-openid-connect-server
 
 ## Description

--- a/readme.txt
+++ b/readme.txt
@@ -1,12 +1,12 @@
 === OpenID Connect Server ===
-Contributors: akirk, ashfame, psrpinto
-Tags: oidc, openid, connect, server
-Requires at least: 5.0
-Tested up to: 6.1
-Requires PHP: 7.1
-License: GPLv2 or later
+Contributors: automattic, akirk, ashfame, psrpinto
+Tags: oidc, oauth, openid, openid connect, oauth server
+Requires at least: 6.0
+Tested up to: 6.0
+Requires PHP: 7.4
+License: GPLv2
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
-Stable tag: trunk
+Stable tag: 1.0
 GitHub Plugin URI: https://github.com/Automattic/wp-openid-connect-server
 
 Use OpenID Connect to log in to other webservices using your own WordPress.

--- a/wp-openid-connect-server.php
+++ b/wp-openid-connect-server.php
@@ -1,11 +1,16 @@
 <?php
 /**
- * Plugin Name: OpenID Connect Server
- * Description: Use OpenID Connect to log in to other webservices using your own WordPress.
- * Author: Automattic
- * Author URI: https://automattic.com/
- * Plugin URI: https://github.com/Automattic/wp-openid-connect-server
- * Version: 1.0
+ * Plugin Name:       OpenID Connect Server
+ * Plugin URI:        https://github.com/Automattic/wp-openid-connect-server
+ * Description:       Use OpenID Connect to log in to other webservices using your own WordPress.
+ * Version:           1.0
+ * Requires at least: 6.0
+ * Requires PHP:      7.4
+ * Author:            Automattic
+ * Author URI:        https://automattic.com/
+ * License:           GPL v2
+ * License URI:       https://www.gnu.org/licenses/gpl-2.0.html
+ * Text Domain:       wp-openid-connect-server
  */
 
 use OpenIDConnectServer\OpenIDConnectServer;


### PR DESCRIPTION
This PR changes the plugin header to an expanded version containing all the fields as per [plugin handbook](https://developer.wordpress.org/plugins/plugin-basics/header-requirements/) & readme file as per [guidelines](https://developer.wordpress.org/plugins/wordpress-org/how-your-readme-txt-works/).

Couple of values worth discussing are the required PHP and WordPress version:

For PHP version, I chose `7.4` since that's in line with [recommended PHP version for WordPress](https://wordpress.org/about/requirements/).
For WP version, I simply chose `6.0` for now, but I am almost certain older versions are supported, but should we try to find what that is? Are there any tools to aid in this process? Or sticking to the latest major release is a good idea?
