### PR TITLE
added code to handle uninstall

### DIFF
--- a/src/OpenIDConnectServer.php
+++ b/src/OpenIDConnectServer.php
@@ -74,4 +74,16 @@ class OpenIDConnectServer {
 			wp_schedule_event( time(), 'weekly', 'oidc_cron_hook' );
 		}
 	}
+
+	/**
+	 * This function is invoked from uninstall.php
+	 *
+	 * As of v1.0 we have two things that are being stored and should be removed on uninstall:
+	 * 1) Consent storage
+	 * 2) Auth code storage
+	 */
+	public static function uninstall() {
+		ConsentStorage::uninstall();
+		AuthorizationCodeStorage::uninstall();
+	}
 }

--- a/src/Storage/AuthorizationCodeStorage.php
+++ b/src/Storage/AuthorizationCodeStorage.php
@@ -115,4 +115,28 @@ class AuthorizationCodeStorage implements AuthorizationCodeInterface {
 			}
 		}
 	}
+
+	public static function uninstall() {
+		global $wpdb;
+
+		// Following query is only possible via a direct query since meta_key is not a fixed string
+		// and since it only runs at uninstall, we don't need it cached
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$data = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT user_id, meta_key FROM $wpdb->usermeta WHERE meta_key LIKE %s",
+				'oidc_expires_%',
+			)
+		);
+		if ( empty( $data ) ) {
+			return;
+		}
+
+		foreach ( $data as $row ) {
+			$code = substr( $row->meta_key, strlen( 'oidc_expires_' ) );
+			foreach ( array_keys( self::$authorization_code_data ) as $key ) {
+				delete_user_meta( $row->user_id, self::META_KEY_PREFIX . '_' . $key . '_' . $code );
+			}
+		}
+	}
 }

--- a/src/Storage/AuthorizationCodeStorage.php
+++ b/src/Storage/AuthorizationCodeStorage.php
@@ -120,7 +120,7 @@ class AuthorizationCodeStorage implements AuthorizationCodeInterface {
 		global $wpdb;
 
 		// Following query is only possible via a direct query since meta_key is not a fixed string
-		// and since it only runs at uninstall, we don't need it cached
+		// and since it only runs at uninstall, we don't need it cached.
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 		$data = $wpdb->get_results(
 			$wpdb->prepare(

--- a/src/Storage/ConsentStorage.php
+++ b/src/Storage/ConsentStorage.php
@@ -39,8 +39,7 @@ class ConsentStorage {
 		}
 
 		foreach ( $data as $row ) {
-			$client_id = substr( $row->meta_key, strlen( 'oidc_consent_timestamp_' ) );
-			delete_user_meta( $row->user_id, 'oidc_consent_timestamp_' . $client_id );
+			delete_user_meta( $row->user_id, $row->meta_key );
 		}
 	}
 }

--- a/src/Storage/ConsentStorage.php
+++ b/src/Storage/ConsentStorage.php
@@ -26,7 +26,7 @@ class ConsentStorage {
 		global $wpdb;
 
 		// Following query is only possible via a direct query since meta_key is not a fixed string
-		// and since it only runs at uninstall, we don't need it cached
+		// and since it only runs at uninstall, we don't need it cached.
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 		$data = $wpdb->get_results(
 			$wpdb->prepare(

--- a/src/Storage/ConsentStorage.php
+++ b/src/Storage/ConsentStorage.php
@@ -3,11 +3,12 @@
 namespace OpenIDConnectServer\Storage;
 
 const STICKY_CONSENT_DURATION = 7 * DAY_IN_SECONDS;
-const META_KEY_PREFIX         = 'oidc_consent_timestamp';
 
 class ConsentStorage {
+	const META_KEY_PREFIX = 'oidc_consent_timestamp_';
+
 	private function get_meta_key( $client_id ) : string {
-		return META_KEY_PREFIX . '_' . $client_id;
+		return self::META_KEY_PREFIX . $client_id;
 	}
 
 	public function needs_consent( $user_id, $client_id ): bool {
@@ -31,7 +32,7 @@ class ConsentStorage {
 		$data = $wpdb->get_results(
 			$wpdb->prepare(
 				"SELECT user_id, meta_key FROM $wpdb->usermeta WHERE meta_key LIKE %s",
-				'oidc_consent_timestamp_%',
+				self::META_KEY_PREFIX . '%',
 			)
 		);
 		if ( empty( $data ) ) {

--- a/uninstall.php
+++ b/uninstall.php
@@ -1,0 +1,10 @@
+<?php
+
+use OpenIDConnectServer\OpenIDConnectServer;
+
+// if uninstall.php is not called by WordPress, die.
+if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
+	die;
+}
+
+OpenIDConnectServer::uninstall();


### PR DESCRIPTION
This PR adds code to handle [uninstall](https://developer.wordpress.org/plugins/plugin-basics/uninstall-methods/), when the plugin is deleted from WP admin.