### PR TITLE
Release automation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,25 +15,15 @@ wp-env run cli "wp rewrite structure '/%postname%'"
 
 The site is now available at http://localhost:8888.
 
+## Releasing
+Releases are automatically created through a GitHub Action, which is executed whenever a tag of the form `vX.Y.Z` is pushed.
 
-## Release
-Plugin releases are automatically created through a GitHub Action, which is executed whenever a tag of the form `vX.Y.Z` is pushed. You can create and push a tag as follows.
-
-First find the latest tag:
-
-```shell
-# Fetch tags from origin
-git fetch
-
-# Returns the latest tag, e.g. v0.1.0
-git describe --tags --abbrev=0
-```
-
-Then create and push a tag that increments the latest one as per [Semantic Versioning](https://semver.org/):
+You can create and push a tag with:
 
 ```shell
-git tag v0.1.1
-git push origin v0.1.1
+# Make sure you consider https://semver.org to decide which version you're issuing.
+# Note the version must not be prefixed with a "v", e.g. it should be 1.2.3, not v1.2.3.  
+bin/prepare-release.sh 1.2.3
 ```
 
-The [GitHub Action](https://github.com/Automattic/wp-openid-connect-server/actions) will launch automatically, and when completed will have created a **draft release** for the tag that was pushed. You should then edit that release to provide a meaningful title and description (ideally including a [changelog](https://keepachangelog.com/en/1.0.0/)), then publish the release.
+Running the above script will trigger the [GitHub Action](https://github.com/Automattic/wp-openid-connect-server/actions), which when completed will have created a **draft release** for the tag that was pushed. You should then edit that release to provide a meaningful title and description (ideally including a [changelog](https://keepachangelog.com/en/1.0.0/)), then publish the release through the GitHub UI.

--- a/bin/prepare-release.sh
+++ b/bin/prepare-release.sh
@@ -1,0 +1,24 @@
+set -e
+
+if [ -z "$1" ]; then
+    echo "Provide a new version, current version is $(jq '.version' composer.json)"
+    exit 1
+fi
+
+VERSION=$1
+
+git checkout main
+git fetch
+git pull origin main
+
+jq ".version = \"$VERSION\"" composer.json > composer.json.tmp
+mv composer.json.tmp composer.json
+git add composer.json
+
+sed -i"" -e "s/\(Version: \)\(.*\)/\1          $VERSION/g" wp-openid-connect-server.php
+rm -f wp-openid-connect-server.php-e
+git add wp-openid-connect-server.php
+
+git commit -m "Release v$VERSION"
+git tag "v$VERSION"
+git push --tags origin main

--- a/composer.json
+++ b/composer.json
@@ -1,28 +1,28 @@
 {
-    "require": {
-        "ext-json": "*",
-        "ext-openssl": "*",
-        "bshaffer/oauth2-server-php": "^1.12"
-    },
-    "require-dev": {
-        "dealerdirect/phpcodesniffer-composer-installer": "^0.7.2",
-        "johnpbloch/wordpress": "^6.0",
-        "squizlabs/php_codesniffer": "^3.7",
-        "wp-coding-standards/wpcs": "^2.3"
-    },
-    "autoload": {
-        "psr-4": {
-            "OpenIDConnectServer\\": "src/"
-        }
-    },
-    "scripts": {
-        "phpcs": "phpcs --standard=phpcs.xml"
-    },
-    "config": {
-        "sort-packages": true,
-        "allow-plugins": {
-            "johnpbloch/wordpress-core-installer": false,
-            "dealerdirect/phpcodesniffer-composer-installer": true
-        }
+  "require": {
+    "ext-json": "*",
+    "ext-openssl": "*",
+    "bshaffer/oauth2-server-php": "^1.12"
+  },
+  "require-dev": {
+    "dealerdirect/phpcodesniffer-composer-installer": "^0.7.2",
+    "johnpbloch/wordpress": "^6.0",
+    "squizlabs/php_codesniffer": "^3.7",
+    "wp-coding-standards/wpcs": "^2.3"
+  },
+  "autoload": {
+    "psr-4": {
+      "OpenIDConnectServer\\": "src/"
     }
+  },
+  "scripts": {
+    "phpcs": "phpcs --standard=phpcs.xml"
+  },
+  "config": {
+    "sort-packages": true,
+    "allow-plugins": {
+      "johnpbloch/wordpress-core-installer": false,
+      "dealerdirect/phpcodesniffer-composer-installer": true
+    }
+  }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,4 +1,5 @@
 {
+  "version": "0.1.0",
   "require": {
     "ext-json": "*",
     "ext-openssl": "*",

--- a/wp-openid-connect-server.php
+++ b/wp-openid-connect-server.php
@@ -3,7 +3,7 @@
  * Plugin Name:       OpenID Connect Server
  * Plugin URI:        https://github.com/Automattic/wp-openid-connect-server
  * Description:       Use OpenID Connect to log in to other webservices using your own WordPress.
- * Version:           1.0
+ * Version:           0.1.0
  * Requires at least: 6.0
  * Requires PHP:      7.4
  * Author:            Automattic


### PR DESCRIPTION
Add a script to prepare a release, which automatically sets the version in `wp-openid-connect-server.php`.

(I did this for chatrix and thought I might as well suggest the change here).