### PR TITLE
Update GitHub action workflow for "creating a release"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,10 +40,10 @@ jobs:
           rm -rf /tmp/release/phpcs.xml
 
       - name: Move and rename release directory
-        run: mv /tmp/release wp-openid-connect-server
+        run: mv /tmp/release openid-connect-server
 
-      - name: Create archive for release
-        run: tar -cvzf wp-openid-connect-server-${{ github.ref_name }}.tar.gz wp-openid-connect-server
+      - name: Create tar archive file for release
+        run: tar -cvzf wp-openid-connect-server-${{ github.ref_name }}.tar.gz openid-connect-server
 
       - name: Create release
         uses: ncipollo/release-action@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,11 @@ jobs:
       - name: Move and rename release directory
         run: mv /tmp/release openid-connect-server
 
+      - name: Create zip archive file for release
+        uses: montudor/action-zip@v1
+        with:
+          args: zip -qq -r wp-openid-connect-server-${{ github.ref_name }}.zip openid-connect-server
+
       - name: Create tar archive file for release
         run: tar -cvzf wp-openid-connect-server-${{ github.ref_name }}.tar.gz openid-connect-server
 
@@ -50,6 +55,6 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           tag: ${{ github.ref_name }}
-          artifacts: "wp-openid-connect-server-${{ github.ref_name }}.tar.gz"
+          artifacts: "wp-openid-connect-server-${{ github.ref_name }}.tar.gz,wp-openid-connect-server-${{ github.ref_name }}.zip"
           artifactErrorsFailBuild: true
           draft: true


### PR DESCRIPTION
This PR changes the directory name for release from `wp-openid-connect-server` to `openid-connect-server` as release directory being `wp-openid-connect-server` same as repo name caused a weird behavior (most likely a bug at Github's end) to use the cloned repo be used for creating release archive files instead of this release directory that's moved from `/tmp` to the current working directory where Github action workflow runs.

Additionally, also create a zip archive file as artifcat in addition to a tar archive file.