### PR TITLE
fix user_id that's passed to OIDC client is supposed to be user_login

### DIFF
--- a/src/Storage/AuthorizationCodeStorage.php
+++ b/src/Storage/AuthorizationCodeStorage.php
@@ -51,8 +51,10 @@ class AuthorizationCodeStorage implements AuthorizationCodeInterface {
 			return null;
 		}
 
+		$user = new \WP_User( $user_id );
+
 		$authorization_code = array(
-			'user_id' => $user_id,
+			'user_id' => $user->user_login,
 			'code'    => $code,
 		);
 		foreach ( array_keys( self::$authorization_code_data ) as $key ) {


### PR DESCRIPTION
This PR changes back the `user_id` presented in OIDC context to be `user_login` as [decided earlier](https://github.com/Automattic/wp-openid-connect-server/pull/10). This was mistakenly changed to be just the user ID in 114926c4efa6f13a74f5622c8f290c8bcea2b945 when we were changing AuthCodeStorage to be usermeta based.