### PR TITLE
remove md bold syntax and description before tags for correct parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 # OpenID Connect Server
 
-Use OpenID Connect to log in to other webservices using your own WordPress.
+Contributors: automattic, akirk, ashfame, psrpinto
+Tags: oidc, oauth, openid, openid connect, oauth server
+Requires at least: 6.0
+Tested up to: 6.1
+Requires PHP: 7.4
+License: [GPLv2](http://www.gnu.org/licenses/gpl-2.0.html)
+Stable tag: 1.1.0
+GitHub Plugin URI: https://github.com/Automattic/wp-openid-connect-server
 
-**Contributors:** automattic, akirk, ashfame, psrpinto
-**Tags:** oidc, oauth, openid, openid connect, oauth server
-**Requires at least:** 6.0
-**Tested up to:** 6.1
-**Requires PHP:** 7.4
-**License:** [GPLv2](http://www.gnu.org/licenses/gpl-2.0.html)
-**Stable tag:** 1.0
-**GitHub Plugin URI:** https://github.com/Automattic/wp-openid-connect-server
+Use OpenID Connect to log in to other webservices using your own WordPress.
 
 ## Description
 


### PR DESCRIPTION
This PR includes changes to our readme.md for correct parsing of tags.

- tag names shouldn't be bold
- no description before tags

Already fixed on svn, so just need to include these changes here.