### PR TITLE
Update readme regarding supported means of client auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ function my_oidc_clients() {
 	);
 }
 ~~~
-Note: Currently only [POST based client authentication - `client_secret_post`](https://openid.net/specs/openid-connect-core-1_0.html#ClientAuthentication) is supported.
+**Note:** Currently only [POST based client authentication - `client_secret_post`](https://openid.net/specs/openid-connect-core-1_0.html#ClientAuthentication) is supported.
 
 ### Github Repo
 You can report any issues you encounter directly on [Github repo: Automattic/wp-openid-connect-server](https://github.com/Automattic/wp-openid-connect-server)

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ function my_oidc_clients() {
 	);
 }
 ~~~
+Note: Currently only [POST based client authentication - `client_secret_post`](https://openid.net/specs/openid-connect-core-1_0.html#ClientAuthentication) is supported.
 
 ### Github Repo
 You can report any issues you encounter directly on [Github repo: Automattic/wp-openid-connect-server](https://github.com/Automattic/wp-openid-connect-server)


### PR DESCRIPTION
This PR updates the readme to indicate we currently only support POST based client auth from all the ones listed in OIDC spec