### PR TITLE
Ensure method argument name matches interface as per PHP8 recommendations

### DIFF
--- a/src/Storage/UserClaimsStorage.php
+++ b/src/Storage/UserClaimsStorage.php
@@ -10,6 +10,7 @@ class UserClaimsStorage implements UserClaimsInterface {
 	public function getUserClaims( $user_id, $scope ) {
 		// We use WordPress user_login as the user identifier.
 		$user_login = $user_id;
+
 		$claims = array(
 			// We expose the scope here so that it's in the token (unclear from the specs but the userinfo endpoint reads the scope from the token).
 			'scope' => $scope,

--- a/src/Storage/UserClaimsStorage.php
+++ b/src/Storage/UserClaimsStorage.php
@@ -8,7 +8,7 @@ use OAuth2\OpenID\Storage\UserClaimsInterface;
 
 class UserClaimsStorage implements UserClaimsInterface {
 	public function getUserClaims( $user_id, $scope ) {
-		// We use WordPress user_login as the user identifier
+		// We use WordPress user_login as the user identifier.
 		$user_login = $user_id;
 		$claims = array(
 			// We expose the scope here so that it's in the token (unclear from the specs but the userinfo endpoint reads the scope from the token).

--- a/src/Storage/UserClaimsStorage.php
+++ b/src/Storage/UserClaimsStorage.php
@@ -7,7 +7,9 @@ namespace OpenIDConnectServer\Storage;
 use OAuth2\OpenID\Storage\UserClaimsInterface;
 
 class UserClaimsStorage implements UserClaimsInterface {
-	public function getUserClaims( $user_login, $scope ) {
+	public function getUserClaims( $user_id, $scope ) {
+		// We use WordPress user_login as the user identifier
+		$user_login = $user_id;
 		$claims = array(
 			// We expose the scope here so that it's in the token (unclear from the specs but the userinfo endpoint reads the scope from the token).
 			'scope' => $scope,


### PR DESCRIPTION
This PR changes the recent change to method name so that it matches how its defined in interface as per PHP8 recommendations [here](https://www.php.net/manual/en/language.oop5.interfaces.php).

> Warning: A class that implements an interface may use a different name for its parameters than the interface. However, as of PHP 8.0 the language supports [named arguments](https://www.php.net/manual/en/functions.arguments.php#functions.named-arguments), which means callers may rely on the parameter name in the interface. For that reason, it is strongly recommended that developers use the same parameter names as the interface being implemented.

This takes care of PHPStorm flagging the argument name as well.