### PR TITLE
make wp plugins repo headers in readme show up properly

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # OpenID Connect Server
 
-Contributors: automattic, akirk, ashfame, psrpinto
-Tags: oidc, oauth, openid, openid connect, oauth server
-Requires at least: 6.0
-Tested up to: 6.1
-Requires PHP: 7.4
-License: [GPLv2](http://www.gnu.org/licenses/gpl-2.0.html)
-Stable tag: 1.1.0
-GitHub Plugin URI: https://github.com/Automattic/wp-openid-connect-server
+- Contributors: automattic, akirk, ashfame, psrpinto
+- Tags: oidc, oauth, openid, openid connect, oauth server
+- Requires at least: 6.0
+- Tested up to: 6.1
+- Requires PHP: 7.4
+- License: [GPLv2](http://www.gnu.org/licenses/gpl-2.0.html)
+- Stable tag: 1.1.0
+- GitHub Plugin URI: https://github.com/Automattic/wp-openid-connect-server
 
 Use OpenID Connect to log in to other webservices using your own WordPress.
 


### PR DESCRIPTION
This PR changes the plugins repo headers to render them properly on Github