### PR TITLE
Return display_name as the name property

### DIFF
--- a/src/Storage/UserClaimsStorage.php
+++ b/src/Storage/UserClaimsStorage.php
@@ -32,6 +32,7 @@ class UserClaimsStorage implements UserClaimsInterface {
 
 		$field_map = array(
 			'username'    => 'user_login',
+			'name'        => 'display_name',
 			'given_name'  => 'first_name',
 			'family_name' => 'last_name',
 			'nickname'    => 'user_nicename',


### PR DESCRIPTION
According to OIDC [spec](https://openid.net/specs/openid-connect-basic-1_0.html) (scroll down to section 2.5), the name property should be:

> End-User's full name in displayable form including all name parts, possibly including titles and suffixes, ordered according to the End-User's locale and preferences.

In  this PR we're returning WordPress' `display_name` as the `name` property.

@ashfame There are other properties we could return as well, do you think we should? Thinking specifically of:

- email
- website
- locale
