### PR TITLE
Release 1.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,11 @@ You can report any issues you encounter directly on [Github repo: Automattic/wp-
 
 ## Changelog
 
+### 1.3.0
+
+- Return `display_name` as the `name` property [[#87](https://github.com/Automattic/wp-openid-connect-server/pull/87)]
+- Change text domain to `openid-connect-server`, instead of `wp-openid-connect-server` [[#88](https://github.com/Automattic/wp-openid-connect-server/pull/88)]
+
 ### 1.2.1
 
 - No user facing changes

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 - Tested up to: 6.2
 - Requires PHP: 7.4
 - License: [GPLv2](http://www.gnu.org/licenses/gpl-2.0.html)
-- Stable tag: 1.2.1
+- Stable tag: 1.3.0
 - GitHub Plugin URI: https://github.com/Automattic/wp-openid-connect-server
 
 Use OpenID Connect to log in to other webservices using your own WordPress.

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.2.1",
+  "version": "1.3.0",
   "require": {
     "ext-json": "*",
     "ext-openssl": "*",

--- a/openid-connect-server.php
+++ b/openid-connect-server.php
@@ -3,7 +3,7 @@
  * Plugin Name:       OpenID Connect Server
  * Plugin URI:        https://github.com/Automattic/wp-openid-connect-server
  * Description:       Use OpenID Connect to log in to other webservices using your own WordPress.
- * Version:           1.2.1
+ * Version:           1.3.0
  * Requires at least: 6.0
  * Requires PHP:      7.4
  * Author:            WordPress.Org Community


### PR DESCRIPTION
[Commits since 1.2.1](https://github.com/Automattic/wp-openid-connect-server/compare/1.2.1...release-1.3.0)

## Changelog
- Return `display_name` as the `name` property [[#87](https://github.com/Automattic/wp-openid-connect-server/pull/87)]
- Change text domain to `openid-connect-server`, instead of `wp-openid-connect-server` [[#88](https://github.com/Automattic/wp-openid-connect-server/pull/88)]