### PR TITLE
Prevent userinfo endpoint from being cached

### DIFF
--- a/src/Http/Handlers/UserInfoHandler.php
+++ b/src/Http/Handlers/UserInfoHandler.php
@@ -15,6 +15,11 @@ class UserInfoHandler extends RequestHandler {
 	}
 
 	public function handle( Request $request, Response $response ): Response {
+		// prevent caching plugins from caching this page.
+		if ( ! defined( 'DONOTCACHEPAGE' ) ) {
+			define( 'DONOTCACHEPAGE', true );
+		}
+
 		$response = $this->server->handleUserInfoRequest( $request, $response );
 		$response->addHttpHeaders(
 			array(

--- a/src/Http/Handlers/UserInfoHandler.php
+++ b/src/Http/Handlers/UserInfoHandler.php
@@ -15,6 +15,14 @@ class UserInfoHandler extends RequestHandler {
 	}
 
 	public function handle( Request $request, Response $response ): Response {
-		return $this->server->handleUserInfoRequest( $request );
+		$response = $this->server->handleUserInfoRequest( $request, $response );
+		$response->addHttpHeaders(
+			array(
+				'Cache-Control' => 'no-store',
+				'Pragma'        => 'no-cache',
+			)
+		);
+
+		return $response;
 	}
 }


### PR DESCRIPTION
This PR adds both no-caching headers and `DONOTCACHEPAGE` constant from preventing userinfo endpoint from getting cached.