### PR TITLE
Readme: update example public key format

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ And make them available to the plugin as follows (this needs to be added before 
 
 ~~~php
 define( 'OIDC_PUBLIC_KEY', <<<OIDC_PUBLIC_KEY
------BEGIN RSA PUBLIC KEY-----
+-----BEGIN PUBLIC KEY-----
 ...
------END RSA PUBLIC KEY-----
+-----END PUBLIC KEY-----
 OIDC_PUBLIC_KEY
 );
 


### PR DESCRIPTION
Fixes #103

The readme suggests setting up keys in `wp-config.php`, and suggests using comments like `-----BEGIN RSA PUBLIC KEY-----` to clearly mark the beginning and end of your key.

However, that format:

1. Does not match the output of the `openssl` command.
2. Does not match the format we expect in Tools > Site Health: https://github.com/Automattic/wp-openid-connect-server/blob/ee663a12d9e12d0b5c9e8c7745c3b48c716754b2/src/SiteStatusTests.php#L35

Let's update the example format to match what's expected.