### PR TITLE
Composer autoload for uninstall

### DIFF
--- a/uninstall.php
+++ b/uninstall.php
@@ -2,6 +2,8 @@
 
 use OpenIDConnectServer\OpenIDConnectServer;
 
+require_once __DIR__ . '/vendor/autoload.php';
+
 // if uninstall.php is not called by WordPress, die.
 if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
 	die;


### PR DESCRIPTION
Currently, when removing the plugin, I get the error below:

```
PHP Fatal error:  Uncaught Error: Class 'OpenIDConnectServer\OpenIDConnectServer' not found in /<wp_root_path>/wp-content/plugins/openid-connect-server/uninstall.php:10
Stack trace:
#0 /<wp_root_path>/wp-admin/includes/plugin.php(1245): include_once()
#1 /<wp_root_path>/wp-admin/includes/plugin.php(960): uninstall_plugin('openid-connect-...')
#2 /<wp_root_path>/wp-admin/includes/ajax-actions.php(4748): delete_plugins(Array)
#3 /<wp_root_path>/wp-includes/class-wp-hook.php(324): wp_ajax_delete_plugin('')
#4 /<wp_root_path>/wp-includes/class-wp-hook.php(348): WP_Hook->apply_filters('', Array)
#5 /<wp_root_path>/wp-includes/plugin.php(517): WP_Hook->do_action(Array)
#6 /<wp_root_path>/wp-admin/admin-ajax.php(188): do_action('wp_ajax_delete-...')
#7 {main}
  thrown in /<wp_root_path>/wp-content/plugins/openid-connect-server/uninstall.php on line 10
```

The error can be resolved by autoloading classes in the uninstall script.