### PR TITLE
feat: make client_id and client_secret optional for the token endpoint

### DIFF
--- a/src/OpenIDConnectServer.php
+++ b/src/OpenIDConnectServer.php
@@ -106,11 +106,11 @@ class OpenIDConnectServer {
 					),
 					'client_id'     => array(
 						'type'     => 'string',
-						'required' => true,
+						'required' => false,
 					),
 					'client_secret' => array(
 						'type'     => 'string',
-						'required' => true,
+						'required' => false,
 					),
 					'redirect_uri'  => array(
 						'type'     => 'string',


### PR DESCRIPTION
bshaffer/oauth2-server-php supports sending the client id and secret as http basic auth.  With client id and secret set as required clients that send them via basic auth instead of in the request body will get an error when they try to exchange the token.  This PR allows the client to send the client id and secret either in the request body or basic auth.