### PR TITLE
feat: add a configuration option to support clients that don't require consent

### DIFF
--- a/src/Storage/ClientCredentialsStorage.php
+++ b/src/Storage/ClientCredentialsStorage.php
@@ -25,6 +25,34 @@ class ClientCredentialsStorage implements ClientCredentialsInterface {
 		);
 	}
 
+	public function getClientName( $client_id ) {
+		if ( ! $this->has( $client_id ) ) {
+			return '';
+		}
+
+		$client = $this->get( $client_id );
+
+		if ( empty( $client['name'] ) ) {
+			return '';
+		}
+
+		return $client['name'];
+	}
+
+	public function clientRequiresConsent( $client_id ): bool {
+		if ( ! $this->has( $client_id ) ) {
+			return true;
+		}
+
+		$client = $this->get( $client_id );
+
+		if ( ! array_key_exists( 'requires_consent', $client ) ) {
+			return true;
+		}
+
+		return true === $client['requires_consent'];
+	}
+
 	public function getClientScope( $client_id ) {
 		if ( ! $this->has( $client_id ) ) {
 			return '';

--- a/src/Storage/ClientCredentialsStorage.php
+++ b/src/Storage/ClientCredentialsStorage.php
@@ -50,7 +50,7 @@ class ClientCredentialsStorage implements ClientCredentialsInterface {
 			return true;
 		}
 
-		return true === $client['requires_consent'];
+		return false !== $client['requires_consent'];
 	}
 
 	public function getClientScope( $client_id ) {


### PR DESCRIPTION
for internal applications you might want to skip prompting for consent. With this change you can set your clients array like the array below to not prompt users for consent.

	return array(
		'client_id_random_string' => array(
			'name' => 'The name of the Client',
			'secret' => 'a secret string',
			'redirect_uri' => 'https://example.com/redirect.uri',
			'grant_types' => array( 'authorization_code' ),
			'requires_consent' => false,
		),