### PR TITLE
Bump "Tested up to" tag to WP 6.8

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,5 +1,5 @@
 {
-  "core": "WordPress/WordPress",
+  "core": "WordPress/WordPress#6.8",
   "phpVersion": "7.4",
   "plugins": [ "." ],
   "config": {

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 - Contributors: wordpressdotorg, akirk, ashfame, psrpinto
 - Tags: oidc, oauth, openid, openid connect, oauth server
 - Requires at least: 6.0
-- Tested up to: 6.5
+- Tested up to: 6.8
 - Requires PHP: 7.4
 - License: [GPLv2](http://www.gnu.org/licenses/gpl-2.0.html)
 - Stable tag: 2.0.0


### PR DESCRIPTION
Tested to work on WP 6.8, so bumped on SVN directly and committing here.

[SVN Commit](https://plugins.trac.wordpress.org/changeset/3275762)