### PR TITLE
Fixing PHP warning in HTTP Router

### DIFF
--- a/src/Http/Router.php
+++ b/src/Http/Router.php
@@ -63,7 +63,7 @@ class Router {
 
 		// Requested URI relative to WP install.
 		$uri = isset( $_SERVER['REQUEST_URI'] ) ? esc_url_raw( wp_unslash( $_SERVER['REQUEST_URI'] ) ) : '';
-		$uri =  $installed_dir ? str_replace( $installed_dir, '', $uri ) : $uri;
+		$uri = $installed_dir ? str_replace( $installed_dir, '', $uri ) : $uri;
 
 		$route = strtok( $uri, '?' );
 

--- a/src/Http/Router.php
+++ b/src/Http/Router.php
@@ -63,7 +63,7 @@ class Router {
 
 		// Requested URI relative to WP install.
 		$uri = isset( $_SERVER['REQUEST_URI'] ) ? esc_url_raw( wp_unslash( $_SERVER['REQUEST_URI'] ) ) : '';
-		$uri = str_replace( $installed_dir, '', $uri );
+		$uri =  $installed_dir ? str_replace( $installed_dir, '', $uri ) : $uri;
 
 		$route = strtok( $uri, '?' );
 


### PR DESCRIPTION
Hey there,
in my dev environment, the following PHP warning is being logged:

```
wp-content/plugins/openid-connect-server/src/Http/Router.php:66
str_replace(): Passing null to parameter #1 ($search) of type array|string is deprecated
```

This PR would fix the warning.