### PR TITLE
Fix Fatal Error: AuthorizationCodeStorage::setAuthorizationCode incom…

### DIFF
--- a/src/Storage/AuthorizationCodeStorage.php
+++ b/src/Storage/AuthorizationCodeStorage.php
@@ -64,7 +64,7 @@ class AuthorizationCodeStorage implements AuthorizationCodeInterface {
 		return $authorization_code;
 	}
 
-	public function setAuthorizationCode( $code, $client_id, $user_id, $redirect_uri, $expires, $scope = null, $id_token = null ) {
+	public function setAuthorizationCode( $code, $client_id, $user_id, $redirect_uri, $expires, $scope = null, $id_token = null, $code_challenge = null, $code_challenge_method = null ) {
 		if ( empty( $code ) ) {
 			return;
 		}


### PR DESCRIPTION
PHP Fatal error: Declaration of OpenIDConnectServer\Storage\AuthorizationCodeStorage::setAuthorizationCode($code, $client_id, $user_id, $redirect_uri, $expires, $scope = null, $id_token = null) must be compatible with OAuth2\OpenID\Storage\AuthorizationCodeInterface::setAuthorizationCode($code, $client_id, $user_id, $redirect_uri, $expires, $scope = null, $id_token = null, $code_challenge = null, $code_challenge_method = null) in /var/www/html/wp-content/plugins/openid-connect-server/src/Storage/AuthorizationCodeStorage.php on line 67