### PR TITLE
chore: pin third-party GitHub Actions to commit SHAs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    groups:
+      actions-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+      actions-major:
+        patterns:
+          - "*"
+        update-types:
+          - "major"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -30,7 +30,7 @@ jobs:
         run: ./bin/create-release-artifacts.sh ${{ inputs.version }}
 
       - name: Create release
-        uses: ncipollo/release-action@v1
+        uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1.21.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           tag: ${{ inputs.version }}

--- a/.github/workflows/on-version-changed.yml
+++ b/.github/workflows/on-version-changed.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           fetch-depth: 2
 
-      - uses: salsify/action-detect-and-tag-new-version@v2
+      - uses: salsify/action-detect-and-tag-new-version@b1778166f13188a9d478e2d1198f993011ba9864 # v2.0.3
         id: check-version
         with:
           version-command: jq '.version' composer.json

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -37,7 +37,7 @@ jobs:
         run: sudo apt-get install subversion -y
 
       - name: Deploy to plugin directory
-        uses: 10up/action-wordpress-plugin-deploy@stable
+        uses: 10up/action-wordpress-plugin-deploy@54bd289b8525fd23a5c365ec369185f2966529c2 # 2.3.0
         with:
           generate-zip: false
         env:


### PR DESCRIPTION
Pins third-party GitHub Actions in this repo to immutable commit SHAs.

This is a draft PR for review before merging. It was prepared with agent assistance and manually verified.

Tracking: DEVPROD-1072

Repo-level summary:
- Pinned distinct third-party action refs in this PR: 3
- Repo-level unpinned usage count from the trunk recheck: 3
- Dependabot GitHub Actions coverage: created (.github/dependabot.yml)


Verification commands:

```bash
# 10up/action-wordpress-plugin-deploy # 2.3.0 -> 54bd289b8525fd23a5c365ec369185f2966529c2
gh api repos/10up/action-wordpress-plugin-deploy/commits/2.3.0 --jq '.sha'
# expected: 54bd289b8525fd23a5c365ec369185f2966529c2

# ncipollo/release-action # v1.21.0 -> 339a81892b84b4eeb0f6e744e4574d79d0d9b8dd
gh api repos/ncipollo/release-action/commits/v1.21.0 --jq '.sha'
# expected: 339a81892b84b4eeb0f6e744e4574d79d0d9b8dd

# salsify/action-detect-and-tag-new-version # v2.0.3 -> b1778166f13188a9d478e2d1198f993011ba9864
gh api repos/salsify/action-detect-and-tag-new-version/commits/v2.0.3 --jq '.sha'
# expected: b1778166f13188a9d478e2d1198f993011ba9864
```
