### PR TITLE
[codex] Add admin settings page

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Use OpenID Connect to log in to other webservices using your own WordPress.
 
 With this plugin you can use your own WordPress install to authenticate with a webservice that provides [OpenID Connect](https://openid.net/connect/) to implement Single-Sign On (SSO) for your users.
 
-The plugin is currently only configured using constants and hooks as follows:
+You can configure the plugin from **Settings > OpenID Connect** in wp-admin, or by using constants and hooks as follows. Constant-defined keys and hook-defined clients take precedence over saved settings and are shown as locked in the admin page.
 
 ### Define the RSA keys
 

--- a/assets/js/settings.js
+++ b/assets/js/settings.js
@@ -1,0 +1,78 @@
+( function () {
+	var rows = document.getElementById( 'oidc-client-rows' );
+	var template = document.getElementById( 'oidc-client-row-template' );
+	var add = document.getElementById( 'oidc-add-client' );
+
+	function randomString( length ) {
+		var chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+		var values = new Uint32Array( length );
+		var output = '';
+		var i;
+
+		window.crypto.getRandomValues( values );
+
+		for ( i = 0; i < length; i++ ) {
+			output += chars[ values[ i ] % chars.length ];
+		}
+
+		return output;
+	}
+
+	function enableFields( row ) {
+		row.querySelectorAll( '[disabled]' ).forEach( function ( field ) {
+			field.disabled = false;
+		} );
+	}
+
+	if ( rows && template && add ) {
+		var nextIndex = parseInt( rows.dataset.nextIndex, 10 ) || 0;
+
+		add.addEventListener( 'click', function ( event ) {
+			var wrapper;
+			var row;
+
+			event.preventDefault();
+
+			wrapper = document.createElement( 'tbody' );
+			wrapper.innerHTML = template.innerHTML.replace( /__INDEX__/g, String( nextIndex++ ) ).trim();
+			row = wrapper.firstElementChild;
+
+			enableFields( row );
+			row.querySelector( '[data-field="client_id"]' ).value = randomString( 32 );
+			row.querySelector( '[data-field="secret"]' ).value = randomString( 48 );
+
+			rows.appendChild( row );
+			row.querySelector( '[data-field="name"]' ).focus();
+		} );
+	}
+
+	document.addEventListener( 'click', function ( event ) {
+		var button = event.target.closest( '.oidc-remove-client,.oidc-generate-client-id,.oidc-generate-secret' );
+		var row;
+
+		if ( ! button ) {
+			return;
+		}
+
+		event.preventDefault();
+
+		row = button.closest( 'tr' );
+		if ( ! row ) {
+			return;
+		}
+
+		if ( button.classList.contains( 'oidc-remove-client' ) ) {
+			row.remove();
+			return;
+		}
+
+		if ( button.classList.contains( 'oidc-generate-client-id' ) ) {
+			row.querySelector( '[data-field="client_id"]' ).value = randomString( 32 );
+			return;
+		}
+
+		if ( button.classList.contains( 'oidc-generate-secret' ) ) {
+			row.querySelector( '[data-field="secret"]' ).value = randomString( 48 );
+		}
+	} );
+}() );

--- a/openid-connect-server.php
+++ b/openid-connect-server.php
@@ -13,22 +13,31 @@
  * Text Domain:       openid-connect-server
  */
 
+use OpenIDConnectServer\Admin\SettingsPage;
+use OpenIDConnectServer\Configuration;
 use OpenIDConnectServer\OpenIDConnectServer;
 use OpenIDConnectServer\SiteStatusTests;
 
 require_once __DIR__ . '/vendor/autoload.php';
+
+if ( is_admin() ) {
+	new SettingsPage();
+}
 
 add_action(
 	'wp_loaded',
 	function () {
 		new SiteStatusTests();
 
-		if ( ! defined( 'OIDC_PUBLIC_KEY' ) || ! defined( 'OIDC_PRIVATE_KEY' ) ) {
-			// Please follow instructions in readme.txt for defining the keys.
+		if ( ! Configuration::has_required_keys() ) {
+			// Please follow instructions in readme.txt or configure the keys in wp-admin.
 			return;
 		}
 
-		$clients = apply_filters( 'oidc_registered_clients', array() ); // Currently the only way to add clients is to use this filter.
-		new OpenIDConnectServer( OIDC_PUBLIC_KEY, OIDC_PRIVATE_KEY, $clients );
+		new OpenIDConnectServer(
+			Configuration::get_public_key(),
+			Configuration::get_private_key(),
+			Configuration::get_clients()
+		);
 	}
 );

--- a/src/Admin/SettingsPage.php
+++ b/src/Admin/SettingsPage.php
@@ -1,0 +1,466 @@
+<?php
+
+namespace OpenIDConnectServer\Admin;
+
+use OpenIDConnectServer\Configuration;
+use OpenIDConnectServer\Http\Router;
+
+class SettingsPage {
+	private const PAGE_SLUG     = 'openid-connect-server';
+	private const NOTICE_KEY    = 'oidc_settings_notices_';
+	private const NONCE_ACTION  = 'oidc_save_settings';
+	private const NONCE_NAME    = 'oidc_settings_nonce';
+	private const OPTION_ACTION = 'oidc_save_settings';
+
+	public function __construct() {
+		add_action( 'admin_menu', array( $this, 'add_menu_page' ) );
+		add_action( 'admin_post_' . self::OPTION_ACTION, array( $this, 'save_settings' ) );
+		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_assets' ) );
+	}
+
+	public function add_menu_page() {
+		add_options_page(
+			__( 'OpenID Connect Server', 'openid-connect-server' ),
+			__( 'OpenID Connect', 'openid-connect-server' ),
+			'manage_options',
+			self::PAGE_SLUG,
+			array( $this, 'render_page' )
+		);
+	}
+
+	public function enqueue_assets( $hook_suffix ) {
+		if ( 'settings_page_' . self::PAGE_SLUG !== $hook_suffix ) {
+			return;
+		}
+
+		wp_register_style( 'openid-connect-server-settings', false, array(), '2.0.0' );
+		wp_enqueue_style( 'openid-connect-server-settings' );
+		wp_add_inline_style(
+			'openid-connect-server-settings',
+			'.oidc-settings textarea{font-family:monospace;width:100%;max-width:900px}.oidc-settings .regular-text{max-width:100%}.oidc-settings-table{max-width:1100px}.oidc-settings-table th{white-space:nowrap}.oidc-settings-table input[type=text],.oidc-settings-table textarea{width:100%}.oidc-settings-table .column-actions{width:100px}.oidc-settings-source{display:inline-block;margin-top:4px;color:#646970}.oidc-settings-code-clients{margin-top:2em}.oidc-provider-urls code{display:block;white-space:normal;word-break:break-all}'
+		);
+
+		wp_register_script( 'openid-connect-server-settings', false, array(), '2.0.0', true );
+		wp_enqueue_script( 'openid-connect-server-settings' );
+		wp_add_inline_script(
+			'openid-connect-server-settings',
+			"(function(){var rows=document.getElementById('oidc-client-rows');var template=document.getElementById('oidc-client-row-template');var add=document.getElementById('oidc-add-client');function randomString(length){var chars='ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';var values=new Uint32Array(length);window.crypto.getRandomValues(values);var output='';for(var i=0;i<length;i++){output+=chars[values[i]%chars.length];}return output;}function enableFields(row){row.querySelectorAll('[disabled]').forEach(function(field){field.disabled=false;});}if(rows&&template&&add){var nextIndex=parseInt(rows.dataset.nextIndex,10)||0;add.addEventListener('click',function(event){event.preventDefault();var wrapper=document.createElement('tbody');wrapper.innerHTML=template.innerHTML.replace(/__INDEX__/g,String(nextIndex++)).trim();var row=wrapper.firstElementChild;enableFields(row);row.querySelector('[data-field=\"client_id\"]').value=randomString(32);row.querySelector('[data-field=\"secret\"]').value=randomString(48);rows.appendChild(row);row.querySelector('[data-field=\"name\"]').focus();});}document.addEventListener('click',function(event){var button=event.target.closest('.oidc-remove-client,.oidc-generate-client-id,.oidc-generate-secret');if(!button){return;}event.preventDefault();var row=button.closest('tr');if(!row){return;}if(button.classList.contains('oidc-remove-client')){row.remove();return;}if(button.classList.contains('oidc-generate-client-id')){row.querySelector('[data-field=\"client_id\"]').value=randomString(32);return;}if(button.classList.contains('oidc-generate-secret')){row.querySelector('[data-field=\"secret\"]').value=randomString(48);}});})();"
+		);
+	}
+
+	public function render_page() {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return;
+		}
+
+		$option_clients   = Configuration::get_option_clients();
+		$filtered_clients = Configuration::get_filtered_clients();
+		?>
+		<div class="wrap oidc-settings">
+			<h1><?php esc_html_e( 'OpenID Connect Server', 'openid-connect-server' ); ?></h1>
+			<?php $this->render_notices(); ?>
+
+			<form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
+				<input type="hidden" name="action" value="<?php echo esc_attr( self::OPTION_ACTION ); ?>" />
+				<?php wp_nonce_field( self::NONCE_ACTION, self::NONCE_NAME ); ?>
+
+				<?php $this->render_key_fields(); ?>
+				<?php $this->render_client_fields( $option_clients, $filtered_clients ); ?>
+
+				<?php submit_button( __( 'Save Settings', 'openid-connect-server' ) ); ?>
+			</form>
+
+			<?php $this->render_provider_urls(); ?>
+		</div>
+		<?php
+	}
+
+	public function save_settings() {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_die( esc_html__( 'You do not have permission to manage OpenID Connect settings.', 'openid-connect-server' ) );
+		}
+
+		check_admin_referer( self::NONCE_ACTION, self::NONCE_NAME );
+
+		$existing_settings = Configuration::get_settings();
+		$settings          = $existing_settings;
+		$errors            = array();
+		$raw_settings      = array();
+
+		if ( isset( $_POST['oidc_settings'] ) && is_array( $_POST['oidc_settings'] ) ) {
+			// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Values are sanitized per field below to avoid corrupting PEM keys and client secrets.
+			$raw_settings = wp_unslash( $_POST['oidc_settings'] );
+		}
+
+		if ( ! Configuration::is_public_key_locked() ) {
+			$public_key = $this->normalize_multiline_secret( $raw_settings['public_key'] ?? '' );
+			if ( '' === $public_key || ! Configuration::has_valid_public_key( $public_key ) ) {
+				$errors[] = __( 'The public key must be a valid PEM public key.', 'openid-connect-server' );
+			}
+			$settings['public_key'] = $public_key;
+		}
+
+		if ( ! Configuration::is_private_key_locked() ) {
+			$private_key = $this->normalize_multiline_secret( $raw_settings['private_key'] ?? '' );
+			if ( '' === $private_key || ! Configuration::has_valid_private_key( $private_key ) ) {
+				$errors[] = __( 'The private key must be a valid PEM private key.', 'openid-connect-server' );
+			}
+			$settings['private_key'] = $private_key;
+		}
+
+		$clients_result      = $this->sanitize_clients( $raw_settings['clients'] ?? array() );
+		$settings['clients'] = $clients_result['clients'];
+		$errors              = array_merge( $errors, $clients_result['errors'] );
+
+		if ( ! empty( $errors ) ) {
+			$this->redirect_with_notices( $errors, 'error' );
+		}
+
+		update_option( Configuration::OPTION_NAME, $settings, false );
+		$this->redirect_with_notices( array( __( 'OpenID Connect settings saved.', 'openid-connect-server' ) ), 'success' );
+	}
+
+	private function render_key_fields() {
+		$public_key_locked  = Configuration::is_public_key_locked();
+		$private_key_locked = Configuration::is_private_key_locked();
+		?>
+		<h2><?php esc_html_e( 'RSA Keys', 'openid-connect-server' ); ?></h2>
+		<table class="form-table" role="presentation">
+			<tbody>
+				<tr>
+					<th scope="row">
+						<label for="oidc-public-key"><?php esc_html_e( 'Public key', 'openid-connect-server' ); ?></label>
+					</th>
+					<td>
+						<textarea id="oidc-public-key" name="oidc_settings[public_key]" rows="8" <?php disabled( $public_key_locked ); ?>><?php echo esc_textarea( Configuration::get_public_key() ); ?></textarea>
+						<p class="description">
+							<?php
+							if ( $public_key_locked ) {
+								esc_html_e( 'Defined by the OIDC_PUBLIC_KEY constant and locked for editing.', 'openid-connect-server' );
+							} else {
+								esc_html_e( 'Paste the PEM-formatted public key.', 'openid-connect-server' );
+							}
+							?>
+						</p>
+					</td>
+				</tr>
+				<tr>
+					<th scope="row">
+						<label for="oidc-private-key"><?php esc_html_e( 'Private key', 'openid-connect-server' ); ?></label>
+					</th>
+					<td>
+						<textarea id="oidc-private-key" name="oidc_settings[private_key]" rows="12" <?php disabled( $private_key_locked ); ?>><?php echo esc_textarea( Configuration::get_private_key() ); ?></textarea>
+						<p class="description">
+							<?php
+							if ( $private_key_locked ) {
+								esc_html_e( 'Defined by the OIDC_PRIVATE_KEY constant and locked for editing.', 'openid-connect-server' );
+							} else {
+								esc_html_e( 'Paste the PEM-formatted private key.', 'openid-connect-server' );
+							}
+							?>
+						</p>
+					</td>
+				</tr>
+			</tbody>
+		</table>
+		<?php
+	}
+
+	private function render_client_fields( array $option_clients, array $filtered_clients ) {
+		$index = 0;
+		?>
+		<h2><?php esc_html_e( 'Clients', 'openid-connect-server' ); ?></h2>
+		<p><?php esc_html_e( 'Configure clients that can authenticate users through this WordPress site.', 'openid-connect-server' ); ?></p>
+		<table class="widefat striped oidc-settings-table">
+			<thead>
+				<tr>
+					<th><?php esc_html_e( 'Client ID', 'openid-connect-server' ); ?></th>
+					<th><?php esc_html_e( 'Name', 'openid-connect-server' ); ?></th>
+					<th><?php esc_html_e( 'Secret', 'openid-connect-server' ); ?></th>
+					<th><?php esc_html_e( 'Redirect URI', 'openid-connect-server' ); ?></th>
+					<th><?php esc_html_e( 'Scope', 'openid-connect-server' ); ?></th>
+					<th><?php esc_html_e( 'Consent', 'openid-connect-server' ); ?></th>
+					<th class="column-actions"><?php esc_html_e( 'Actions', 'openid-connect-server' ); ?></th>
+				</tr>
+			</thead>
+			<tbody id="oidc-client-rows" data-next-index="<?php echo esc_attr( count( $option_clients ) ); ?>">
+				<?php foreach ( $option_clients as $client_id => $client ) : ?>
+					<?php $this->render_editable_client_row( $index, (string) $client_id, is_array( $client ) ? $client : array() ); ?>
+					<?php ++$index; ?>
+				<?php endforeach; ?>
+			</tbody>
+		</table>
+		<p>
+			<button type="button" class="button" id="oidc-add-client"><?php esc_html_e( 'Add Client', 'openid-connect-server' ); ?></button>
+		</p>
+
+		<script type="text/html" id="oidc-client-row-template">
+			<?php $this->render_editable_client_row( '__INDEX__', '', array(), true ); ?>
+		</script>
+
+		<?php $this->render_filtered_clients( $filtered_clients ); ?>
+		<?php
+	}
+
+	private function render_editable_client_row( $index, string $client_id, array $client, bool $template = false ) {
+		$name             = isset( $client['name'] ) ? (string) $client['name'] : '';
+		$secret           = isset( $client['secret'] ) ? (string) $client['secret'] : '';
+		$redirect_uri     = isset( $client['redirect_uri'] ) ? (string) $client['redirect_uri'] : '';
+		$scope            = isset( $client['scope'] ) ? (string) $client['scope'] : Configuration::DEFAULT_SCOPE;
+		$requires_consent = ! array_key_exists( 'requires_consent', $client ) || false !== $client['requires_consent'];
+		$disabled         = $template ? ' disabled' : '';
+		?>
+		<tr>
+			<td>
+				<input type="text" class="regular-text" data-field="client_id" name="oidc_settings[clients][<?php echo esc_attr( (string) $index ); ?>][client_id]" value="<?php echo esc_attr( $client_id ); ?>"<?php echo esc_attr( $disabled ); ?> />
+				<button type="button" class="button button-small oidc-generate-client-id"<?php echo esc_attr( $disabled ); ?>><?php esc_html_e( 'Generate', 'openid-connect-server' ); ?></button>
+			</td>
+			<td>
+				<input type="text" class="regular-text" data-field="name" name="oidc_settings[clients][<?php echo esc_attr( (string) $index ); ?>][name]" value="<?php echo esc_attr( $name ); ?>"<?php echo esc_attr( $disabled ); ?> />
+			</td>
+			<td>
+				<textarea rows="2" data-field="secret" name="oidc_settings[clients][<?php echo esc_attr( (string) $index ); ?>][secret]"<?php echo esc_attr( $disabled ); ?>><?php echo esc_textarea( $secret ); ?></textarea>
+				<button type="button" class="button button-small oidc-generate-secret"<?php echo esc_attr( $disabled ); ?>><?php esc_html_e( 'Generate', 'openid-connect-server' ); ?></button>
+			</td>
+			<td>
+				<input type="text" class="regular-text" data-field="redirect_uri" name="oidc_settings[clients][<?php echo esc_attr( (string) $index ); ?>][redirect_uri]" value="<?php echo esc_attr( $redirect_uri ); ?>" placeholder="https://example.com/callback"<?php echo esc_attr( $disabled ); ?> />
+			</td>
+			<td>
+				<input type="text" class="regular-text" data-field="scope" name="oidc_settings[clients][<?php echo esc_attr( (string) $index ); ?>][scope]" value="<?php echo esc_attr( $scope ); ?>"<?php echo esc_attr( $disabled ); ?> />
+				<input type="hidden" name="oidc_settings[clients][<?php echo esc_attr( (string) $index ); ?>][grant_types][]" value="authorization_code"<?php echo esc_attr( $disabled ); ?> />
+			</td>
+			<td>
+				<label>
+					<input type="checkbox" name="oidc_settings[clients][<?php echo esc_attr( (string) $index ); ?>][requires_consent]" value="1" <?php checked( $requires_consent ); ?><?php echo esc_attr( $disabled ); ?> />
+					<?php esc_html_e( 'Required', 'openid-connect-server' ); ?>
+				</label>
+			</td>
+			<td>
+				<button type="button" class="button-link-delete oidc-remove-client"<?php echo esc_attr( $disabled ); ?>><?php esc_html_e( 'Remove', 'openid-connect-server' ); ?></button>
+			</td>
+		</tr>
+		<?php
+	}
+
+	private function render_filtered_clients( array $filtered_clients ) {
+		if ( empty( $filtered_clients ) ) {
+			return;
+		}
+		?>
+		<div class="oidc-settings-code-clients">
+			<h3><?php esc_html_e( 'Clients defined in code', 'openid-connect-server' ); ?></h3>
+			<p><?php esc_html_e( 'These clients are provided by the oidc_registered_clients filter and are locked for editing.', 'openid-connect-server' ); ?></p>
+			<table class="widefat striped oidc-settings-table">
+				<thead>
+					<tr>
+						<th><?php esc_html_e( 'Client ID', 'openid-connect-server' ); ?></th>
+						<th><?php esc_html_e( 'Name', 'openid-connect-server' ); ?></th>
+						<th><?php esc_html_e( 'Secret', 'openid-connect-server' ); ?></th>
+						<th><?php esc_html_e( 'Redirect URI', 'openid-connect-server' ); ?></th>
+						<th><?php esc_html_e( 'Scope', 'openid-connect-server' ); ?></th>
+						<th><?php esc_html_e( 'Consent', 'openid-connect-server' ); ?></th>
+					</tr>
+				</thead>
+				<tbody>
+					<?php foreach ( $filtered_clients as $client_id => $client ) : ?>
+						<?php $client = is_array( $client ) ? $client : array(); ?>
+						<tr>
+							<td><input type="text" value="<?php echo esc_attr( (string) $client_id ); ?>" disabled /></td>
+							<td><input type="text" value="<?php echo esc_attr( isset( $client['name'] ) ? (string) $client['name'] : '' ); ?>" disabled /></td>
+							<td><textarea rows="2" disabled><?php echo esc_textarea( isset( $client['secret'] ) ? (string) $client['secret'] : '' ); ?></textarea></td>
+							<td><input type="text" value="<?php echo esc_attr( isset( $client['redirect_uri'] ) ? (string) $client['redirect_uri'] : '' ); ?>" disabled /></td>
+							<td><input type="text" value="<?php echo esc_attr( isset( $client['scope'] ) ? (string) $client['scope'] : '' ); ?>" disabled /></td>
+							<td><input type="text" value="<?php echo esc_attr( ! array_key_exists( 'requires_consent', $client ) || false !== $client['requires_consent'] ? __( 'Required', 'openid-connect-server' ) : __( 'Not required', 'openid-connect-server' ) ); ?>" disabled /></td>
+						</tr>
+					<?php endforeach; ?>
+				</tbody>
+			</table>
+		</div>
+		<?php
+	}
+
+	private function render_provider_urls() {
+		$urls = array(
+			array(
+				'label' => __( 'Issuer', 'openid-connect-server' ),
+				'url'   => Router::make_url(),
+			),
+			array(
+				'label' => __( 'Discovery', 'openid-connect-server' ),
+				'url'   => Router::make_url( '.well-known/openid-configuration' ),
+			),
+			array(
+				'label' => __( 'JWKS', 'openid-connect-server' ),
+				'url'   => Router::make_url( '.well-known/jwks.json' ),
+			),
+			array(
+				'label' => __( 'Authorization endpoint', 'openid-connect-server' ),
+				'url'   => Router::make_rest_url( 'authorize' ),
+			),
+			array(
+				'label' => __( 'Token endpoint', 'openid-connect-server' ),
+				'url'   => Router::make_rest_url( 'token' ),
+			),
+			array(
+				'label' => __( 'Userinfo endpoint', 'openid-connect-server' ),
+				'url'   => Router::make_rest_url( 'userinfo' ),
+			),
+		);
+		?>
+		<h2><?php esc_html_e( 'Provider URLs', 'openid-connect-server' ); ?></h2>
+		<table class="form-table oidc-provider-urls" role="presentation">
+			<tbody>
+				<?php foreach ( $urls as $provider_url ) : ?>
+					<tr>
+						<th scope="row"><?php echo esc_html( $provider_url['label'] ); ?></th>
+						<td><code><?php echo esc_url( $provider_url['url'] ); ?></code></td>
+					</tr>
+				<?php endforeach; ?>
+			</tbody>
+		</table>
+		<?php
+	}
+
+	private function sanitize_clients( $raw_clients ): array {
+		$clients          = array();
+		$errors           = array();
+		$filtered_clients = Configuration::get_filtered_clients();
+
+		if ( ! is_array( $raw_clients ) ) {
+			return array(
+				'clients' => $clients,
+				'errors'  => $errors,
+			);
+		}
+
+		foreach ( $raw_clients as $raw_client ) {
+			if ( ! is_array( $raw_client ) ) {
+				continue;
+			}
+
+			$client_id    = isset( $raw_client['client_id'] ) ? sanitize_text_field( $raw_client['client_id'] ) : '';
+			$name         = isset( $raw_client['name'] ) ? sanitize_text_field( $raw_client['name'] ) : '';
+			$secret       = isset( $raw_client['secret'] ) ? trim( (string) $raw_client['secret'] ) : '';
+			$redirect_uri = isset( $raw_client['redirect_uri'] ) ? esc_url_raw( trim( (string) $raw_client['redirect_uri'] ) ) : '';
+			$scope        = isset( $raw_client['scope'] ) ? sanitize_text_field( $raw_client['scope'] ) : Configuration::DEFAULT_SCOPE;
+
+			if ( '' === $client_id && '' === $name && '' === $secret && '' === $redirect_uri ) {
+				continue;
+			}
+
+			if ( strlen( $client_id ) < 10 ) {
+				$errors[] = __( 'Each client ID must be at least 10 characters long.', 'openid-connect-server' );
+				continue;
+			}
+
+			if ( isset( $clients[ $client_id ] ) ) {
+				$errors[] = sprintf(
+					// translators: %s is an OpenID Connect client ID.
+					__( 'The client ID %s is duplicated.', 'openid-connect-server' ),
+					$client_id
+				);
+				continue;
+			}
+
+			if ( isset( $filtered_clients[ $client_id ] ) ) {
+				$errors[] = sprintf(
+					// translators: %s is an OpenID Connect client ID.
+					__( 'The client ID %s is already defined in code and cannot be saved from the settings page.', 'openid-connect-server' ),
+					$client_id
+				);
+				continue;
+			}
+
+			if ( '' === $name ) {
+				$errors[] = sprintf(
+					// translators: %s is an OpenID Connect client ID.
+					__( 'The client %s needs a name.', 'openid-connect-server' ),
+					$client_id
+				);
+				continue;
+			}
+
+			if ( '' === $secret ) {
+				$errors[] = sprintf(
+					// translators: %s is an OpenID Connect client ID.
+					__( 'The client %s needs a secret.', 'openid-connect-server' ),
+					$client_id
+				);
+				continue;
+			}
+
+			if ( '' === $redirect_uri ) {
+				$errors[] = sprintf(
+					// translators: %s is an OpenID Connect client ID.
+					__( 'The client %s needs a redirect URI.', 'openid-connect-server' ),
+					$client_id
+				);
+				continue;
+			}
+
+			if ( ! preg_match( '#^https://#', $redirect_uri ) ) {
+				$errors[] = sprintf(
+					// translators: %s is an OpenID Connect client ID.
+					__( 'The redirect URI for client %s must use HTTPS.', 'openid-connect-server' ),
+					$client_id
+				);
+				continue;
+			}
+
+			$clients[ $client_id ] = array(
+				'name'             => $name,
+				'secret'           => $secret,
+				'redirect_uri'     => $redirect_uri,
+				'grant_types'      => array( 'authorization_code' ),
+				'scope'            => '' === $scope ? Configuration::DEFAULT_SCOPE : $scope,
+				'requires_consent' => isset( $raw_client['requires_consent'] ),
+			);
+		}
+
+		return array(
+			'clients' => $clients,
+			'errors'  => $errors,
+		);
+	}
+
+	private function normalize_multiline_secret( $value ): string {
+		$value = str_replace( "\r\n", "\n", (string) $value );
+		$value = str_replace( "\r", "\n", $value );
+
+		return trim( $value );
+	}
+
+	private function render_notices() {
+		$notices = get_transient( self::NOTICE_KEY . get_current_user_id() );
+		if ( ! is_array( $notices ) ) {
+			return;
+		}
+
+		delete_transient( self::NOTICE_KEY . get_current_user_id() );
+
+		foreach ( $notices as $notice ) {
+			if ( empty( $notice['message'] ) || empty( $notice['type'] ) ) {
+				continue;
+			}
+			?>
+			<div class="notice notice-<?php echo esc_attr( $notice['type'] ); ?> is-dismissible">
+				<p><?php echo esc_html( $notice['message'] ); ?></p>
+			</div>
+			<?php
+		}
+	}
+
+	private function redirect_with_notices( array $messages, string $type ) {
+		$notices = array();
+		foreach ( $messages as $message ) {
+			$notices[] = array(
+				'type'    => $type,
+				'message' => $message,
+			);
+		}
+
+		set_transient( self::NOTICE_KEY . get_current_user_id(), $notices, 30 );
+		wp_safe_redirect( admin_url( 'options-general.php?page=' . self::PAGE_SLUG ) );
+		exit;
+	}
+}

--- a/src/Admin/SettingsPage.php
+++ b/src/Admin/SettingsPage.php
@@ -40,11 +40,12 @@ class SettingsPage {
 			'.oidc-settings textarea{font-family:monospace;width:100%;max-width:900px}.oidc-settings .regular-text{max-width:100%}.oidc-settings-table{max-width:1100px}.oidc-settings-table th{white-space:nowrap}.oidc-settings-table input[type=text],.oidc-settings-table textarea{width:100%}.oidc-settings-table .column-actions{width:100px}.oidc-settings-source{display:inline-block;margin-top:4px;color:#646970}.oidc-settings-code-clients{margin-top:2em}.oidc-provider-urls code{display:block;white-space:normal;word-break:break-all}'
 		);
 
-		wp_register_script( 'openid-connect-server-settings', false, array(), '2.0.0', true );
-		wp_enqueue_script( 'openid-connect-server-settings' );
-		wp_add_inline_script(
+		wp_enqueue_script(
 			'openid-connect-server-settings',
-			"(function(){var rows=document.getElementById('oidc-client-rows');var template=document.getElementById('oidc-client-row-template');var add=document.getElementById('oidc-add-client');function randomString(length){var chars='ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';var values=new Uint32Array(length);window.crypto.getRandomValues(values);var output='';for(var i=0;i<length;i++){output+=chars[values[i]%chars.length];}return output;}function enableFields(row){row.querySelectorAll('[disabled]').forEach(function(field){field.disabled=false;});}if(rows&&template&&add){var nextIndex=parseInt(rows.dataset.nextIndex,10)||0;add.addEventListener('click',function(event){event.preventDefault();var wrapper=document.createElement('tbody');wrapper.innerHTML=template.innerHTML.replace(/__INDEX__/g,String(nextIndex++)).trim();var row=wrapper.firstElementChild;enableFields(row);row.querySelector('[data-field=\"client_id\"]').value=randomString(32);row.querySelector('[data-field=\"secret\"]').value=randomString(48);rows.appendChild(row);row.querySelector('[data-field=\"name\"]').focus();});}document.addEventListener('click',function(event){var button=event.target.closest('.oidc-remove-client,.oidc-generate-client-id,.oidc-generate-secret');if(!button){return;}event.preventDefault();var row=button.closest('tr');if(!row){return;}if(button.classList.contains('oidc-remove-client')){row.remove();return;}if(button.classList.contains('oidc-generate-client-id')){row.querySelector('[data-field=\"client_id\"]').value=randomString(32);return;}if(button.classList.contains('oidc-generate-secret')){row.querySelector('[data-field=\"secret\"]').value=randomString(48);}});})();"
+			plugins_url( 'assets/js/settings.js', dirname( __DIR__, 2 ) . '/openid-connect-server.php' ),
+			array(),
+			'2.0.0',
+			true
 		);
 	}
 

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace OpenIDConnectServer;
+
+class Configuration {
+	public const OPTION_NAME   = 'oidc_server_settings';
+	public const DEFAULT_SCOPE = 'openid profile';
+
+	public static function get_settings(): array {
+		$settings = get_option( self::OPTION_NAME, array() );
+
+		if ( ! is_array( $settings ) ) {
+			return array();
+		}
+
+		return $settings;
+	}
+
+	public static function get_public_key(): string {
+		if ( self::is_public_key_locked() ) {
+			return (string) OIDC_PUBLIC_KEY;
+		}
+
+		$settings = self::get_settings();
+
+		return isset( $settings['public_key'] ) ? (string) $settings['public_key'] : '';
+	}
+
+	public static function get_private_key(): string {
+		if ( self::is_private_key_locked() ) {
+			return (string) OIDC_PRIVATE_KEY;
+		}
+
+		$settings = self::get_settings();
+
+		return isset( $settings['private_key'] ) ? (string) $settings['private_key'] : '';
+	}
+
+	public static function is_public_key_locked(): bool {
+		return defined( 'OIDC_PUBLIC_KEY' );
+	}
+
+	public static function is_private_key_locked(): bool {
+		return defined( 'OIDC_PRIVATE_KEY' );
+	}
+
+	public static function has_required_keys(): bool {
+		return '' !== trim( self::get_public_key() ) && '' !== trim( self::get_private_key() );
+	}
+
+	public static function get_option_clients(): array {
+		$settings = self::get_settings();
+
+		if ( empty( $settings['clients'] ) || ! is_array( $settings['clients'] ) ) {
+			return array();
+		}
+
+		return $settings['clients'];
+	}
+
+	public static function get_filtered_clients(): array {
+		$clients = apply_filters( 'oidc_registered_clients', array() );
+
+		if ( ! is_array( $clients ) ) {
+			return array();
+		}
+
+		return $clients;
+	}
+
+	public static function get_clients(): array {
+		$clients = self::get_option_clients();
+
+		foreach ( self::get_filtered_clients() as $client_id => $client ) {
+			$clients[ $client_id ] = $client;
+		}
+
+		return $clients;
+	}
+
+	public static function has_valid_public_key( string $key ): bool {
+		return (bool) preg_match( '/^-----BEGIN\s.*PUBLIC KEY-----.*-----END\s.*PUBLIC KEY-----$/s', trim( $key ) );
+	}
+
+	public static function has_valid_private_key( string $key ): bool {
+		return (bool) preg_match( '/^-----BEGIN\s.*PRIVATE KEY-----.*-----END\s.*PRIVATE KEY-----$/s', trim( $key ) );
+	}
+
+	public static function uninstall() {
+		delete_option( self::OPTION_NAME );
+	}
+}

--- a/src/OpenIDConnectServer.php
+++ b/src/OpenIDConnectServer.php
@@ -150,5 +150,6 @@ class OpenIDConnectServer {
 	public static function uninstall() {
 		ConsentStorage::uninstall();
 		AuthorizationCodeStorage::uninstall();
+		Configuration::uninstall();
 	}
 }

--- a/src/SiteStatusTests.php
+++ b/src/SiteStatusTests.php
@@ -27,22 +27,20 @@ class SiteStatusTests {
 	}
 
 	public function site_status_test_public_key(): array {
-		$key_is_defined            = defined( 'OIDC_PUBLIC_KEY' );
-		$key_has_valid_pem_headers = (bool) preg_match(
-			'/^-----BEGIN\s.*PUBLIC KEY-----.*-----END\s.*PUBLIC KEY-----$/s',
-			OIDC_PUBLIC_KEY
-		);
+		$public_key                = Configuration::get_public_key();
+		$key_is_defined            = '' !== trim( $public_key );
+		$key_has_valid_pem_headers = $key_is_defined && Configuration::has_valid_public_key( $public_key );
 
 		if ( ! $key_is_defined ) {
-			$label  = __( 'The public key constant OIDC_PUBLIC_KEY is not defined.', 'openid-connect-server' );
+			$label  = __( 'The public key is not configured.', 'openid-connect-server' );
 			$status = 'critical';
 			$badge  = 'red';
 		} elseif ( $key_has_valid_pem_headers ) {
-			$label  = __( 'The public key is defined and in the right format', 'openid-connect-server' );
+			$label  = __( 'The public key is configured and in the right format', 'openid-connect-server' );
 			$status = 'good';
 			$badge  = 'green';
 		} else {
-			$label  = __( 'The public key constant OIDC_PUBLIC_KEY is malformed.', 'openid-connect-server' );
+			$label  = __( 'The public key is malformed.', 'openid-connect-server' );
 			$status = 'critical';
 			$badge  = 'red';
 		}
@@ -71,22 +69,20 @@ class SiteStatusTests {
 	}
 
 	public function site_status_test_private_key(): array {
-		$key_is_defined            = defined( 'OIDC_PRIVATE_KEY' );
-		$key_has_valid_pem_headers = (bool) preg_match(
-			'/^-----BEGIN\s.*PRIVATE KEY-----.*-----END\s.*PRIVATE KEY-----$/s',
-			OIDC_PRIVATE_KEY
-		);
+		$private_key               = Configuration::get_private_key();
+		$key_is_defined            = '' !== trim( $private_key );
+		$key_has_valid_pem_headers = $key_is_defined && Configuration::has_valid_private_key( $private_key );
 
 		if ( ! $key_is_defined ) {
-			$label  = __( 'The private key constant OIDC_PRIVATE_KEY is not defined.', 'openid-connect-server' );
+			$label  = __( 'The private key is not configured.', 'openid-connect-server' );
 			$status = 'critical';
 			$badge  = 'red';
 		} elseif ( $key_has_valid_pem_headers ) {
-			$label  = __( 'The private key is defined and in the right format', 'openid-connect-server' );
+			$label  = __( 'The private key is configured and in the right format', 'openid-connect-server' );
 			$status = 'good';
 			$badge  = 'green';
 		} else {
-			$label  = __( 'The private key constant OIDC_PRIVATE_KEY is malformed.', 'openid-connect-server' );
+			$label  = __( 'The private key is malformed.', 'openid-connect-server' );
 			$status = 'critical';
 			$badge  = 'red';
 		}
@@ -115,7 +111,7 @@ class SiteStatusTests {
 	}
 
 	public function site_status_test_clients(): array {
-		$clients = apply_filters( 'oidc_registered_clients', array() );
+		$clients = Configuration::get_clients();
 		if ( empty( $clients ) ) {
 			$label  = __( 'No clients have been defined.', 'openid-connect-server' );
 			$status = 'critical';
@@ -123,14 +119,16 @@ class SiteStatusTests {
 		} else {
 			$all_clients_ok = true;
 			foreach ( $clients as $client_id => $client ) {
-				$error = false;
+				$client       = is_array( $client ) ? $client : array();
+				$error        = false;
+				$redirect_uri = isset( $client['redirect_uri'] ) ? (string) $client['redirect_uri'] : '';
 				if ( strlen( $client_id ) < 10 ) {
 					$error = __( 'The client id (array key) needs to be a random string.', 'openid-connect-server' );
 				}
-				if ( empty( $client['redirect_uri'] ) ) {
+				if ( empty( $redirect_uri ) ) {
 					$error = __( 'You need to specify a redirect_uri.', 'openid-connect-server' );
 				}
-				if ( ! preg_match( '#^https://#', $client['redirect_uri'] ) ) {
+				if ( ! preg_match( '#^https://#', $redirect_uri ) ) {
 					$error = __( 'The redirect_uri needs to be a HTTPS URL.', 'openid-connect-server' );
 				}
 				if ( empty( $client['name'] ) ) {


### PR DESCRIPTION
## Summary

Adds a backward-compatible wp-admin settings page for OpenID Connect Server configuration.

## Changes

- Adds an effective configuration resolver that gives `OIDC_PUBLIC_KEY` and `OIDC_PRIVATE_KEY` precedence over saved options.
- Adds `Settings > OpenID Connect` for pasted RSA keys, generated client IDs/secrets, editable option-backed clients, locked code-defined values, and provider URL reference.
- Merges option-backed clients with `oidc_registered_clients`, with code-defined clients taking precedence at runtime.
- Updates bootstrap, Site Health, uninstall cleanup, and README copy to use the new option-backed configuration path.

## Validation

- `php -l` on changed PHP files
- `composer phpcs`
